### PR TITLE
feat(monitoreo): add frontend observability layer

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Sidebar from "@/components/layouts/sidebar";
 import Header from "@/components/layouts/header";
+import ReportButton from "@/components/ui/report-button";
 import { useAuth } from "@/app/providers/auth-provider";
 import { ROLES_WITHOUT_SIDEBAR } from "@/lib/navigation/sidebar.config";
 import { canSeeSidebar } from "@/lib/auth/access";
@@ -47,6 +48,7 @@ export default function DefaultLayout({
       <div className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
         <Header />
         <main className="grow [&>*:first-child]:scroll-mt-16">{children}</main>
+        <ReportButton />
       </div>
     </div>
   );

--- a/app/(app)/monitoreo/page.tsx
+++ b/app/(app)/monitoreo/page.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import { useState } from "react";
+import { useAuth } from "@/app/providers/auth-provider";
+import { isAdminUser } from "@/lib/auth/access";
+import { useResourceList } from "@/lib/hooks/use-resource-list";
+import { useUrlFilters } from "@/lib/hooks/use-url-filters";
+import { getRegistrosError, getReportesProblema, actualizarEstadoReporte } from "@/lib/api/monitoreo";
+import type { RegistroError, ReporteProblema, EstadoReporte } from "@/types/monitoreo";
+import AlertBanner from "@/components/ui/alert-banner";
+import SearchInput from "@/components/ui/search-input";
+import Pagination from "@/components/ui/pagination";
+import { DEFAULT_PAGE_SIZE } from "@/lib/constants";
+
+type Tab = "errores" | "reportes";
+
+const ESTADO_OPTIONS: { label: string; value: EstadoReporte | "" }[] = [
+  { label: "Todos los estados", value: "" },
+  { label: "Nuevo", value: "NUEVO" },
+  { label: "Visto", value: "VISTO" },
+  { label: "Resuelto", value: "RESUELTO" },
+];
+
+const ESTADO_LABELS: Record<EstadoReporte, string> = {
+  NUEVO: "Nuevo",
+  VISTO: "Visto",
+  RESUELTO: "Resuelto",
+};
+
+const ESTADO_COLORS: Record<EstadoReporte, string> = {
+  NUEVO: "bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300",
+  VISTO: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
+  RESUELTO: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300",
+};
+
+function formatDate(iso: string | null | undefined) {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("es-EC", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function MonitoreoPage() {
+  const { user } = useAuth();
+  const [activeTab, setActiveTab] = useState<Tab>("errores");
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null);
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+
+  if (!isAdminUser(user)) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center px-4">
+        <div className="text-center space-y-2">
+          <h1 className="text-xl font-semibold text-gray-800 dark:text-gray-100">
+            Acceso restringido
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            No tienes permisos para acceder a esta sección.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <MonitoreoAdminContent
+      activeTab={activeTab}
+      setActiveTab={setActiveTab}
+      actionError={actionError}
+      setActionError={setActionError}
+      actionSuccess={actionSuccess}
+      setActionSuccess={setActionSuccess}
+      updatingId={updatingId}
+      setUpdatingId={setUpdatingId}
+    />
+  );
+}
+
+type ContentProps = {
+  activeTab: Tab;
+  setActiveTab: (t: Tab) => void;
+  actionError: string | null;
+  setActionError: (v: string | null) => void;
+  actionSuccess: string | null;
+  setActionSuccess: (v: string | null) => void;
+  updatingId: number | null;
+  setUpdatingId: (id: number | null) => void;
+};
+
+function MonitoreoAdminContent({
+  activeTab,
+  setActiveTab,
+  actionError,
+  setActionError,
+  actionSuccess,
+  setActionSuccess,
+  updatingId,
+  setUpdatingId,
+}: ContentProps) {
+  const { filters: erroresFilters, page: erroresPage, setFilter: setErrorFilter, setPage: setErrorPage } =
+    useUrlFilters("/monitoreo", { requestId: "", desde: "", hasta: "" });
+
+  const { filters: reportesFilters, page: reportesPage, setFilter: setReporteFilter, setPage: setReportePage } =
+    useUrlFilters("/monitoreo", { requestId: "", estado: "", desde: "", hasta: "" });
+
+  const {
+    items: errores,
+    loading: erroresLoading,
+    error: erroresError,
+    totalPages: erroresTotalPages,
+    currentPage: erroresCurrentPage,
+  } = useResourceList<RegistroError>({
+    queryKey: ["monitoreo-errores", erroresFilters.requestId, erroresFilters.desde, erroresFilters.hasta, erroresPage],
+    queryFn: () =>
+      getRegistrosError({
+        page: erroresPage,
+        limit: DEFAULT_PAGE_SIZE,
+        requestId: erroresFilters.requestId.trim() || undefined,
+        desde: erroresFilters.desde || undefined,
+        hasta: erroresFilters.hasta || undefined,
+      }),
+    page: erroresPage,
+    enabled: activeTab === "errores",
+    select: (res) => {
+      const r = res as Record<string, unknown>;
+      const data = r?.data;
+      if (Array.isArray(data)) return data as RegistroError[];
+      if (data && typeof data === "object") {
+        const nested = data as Record<string, unknown>;
+        return (Array.isArray(nested.items) ? nested.items : []) as RegistroError[];
+      }
+      return [];
+    },
+  });
+
+  const {
+    items: reportes,
+    loading: reportesLoading,
+    error: reportesError,
+    totalPages: reportesTotalPages,
+    currentPage: reportesCurrentPage,
+    refetch: refetchReportes,
+  } = useResourceList<ReporteProblema>({
+    queryKey: ["monitoreo-reportes", reportesFilters.requestId, reportesFilters.estado, reportesFilters.desde, reportesFilters.hasta, reportesPage],
+    queryFn: () =>
+      getReportesProblema({
+        page: reportesPage,
+        limit: DEFAULT_PAGE_SIZE,
+        requestId: reportesFilters.requestId.trim() || undefined,
+        estado: (reportesFilters.estado as EstadoReporte) || undefined,
+        desde: reportesFilters.desde || undefined,
+        hasta: reportesFilters.hasta || undefined,
+      }),
+    page: reportesPage,
+    enabled: activeTab === "reportes",
+    select: (res) => {
+      const r = res as Record<string, unknown>;
+      const data = r?.data;
+      if (Array.isArray(data)) return data as ReporteProblema[];
+      if (data && typeof data === "object") {
+        const nested = data as Record<string, unknown>;
+        return (Array.isArray(nested.items) ? nested.items : []) as ReporteProblema[];
+      }
+      return [];
+    },
+  });
+
+  const handleEstadoChange = async (id: number, estado: EstadoReporte) => {
+    setUpdatingId(id);
+    setActionError(null);
+    setActionSuccess(null);
+    try {
+      await actualizarEstadoReporte(id, estado);
+      setActionSuccess("Estado actualizado correctamente.");
+      refetchReportes();
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : "No se pudo actualizar el estado.");
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-8 w-full max-w-[96rem] mx-auto space-y-6">
+      {(actionError || actionSuccess) && (
+        <div className="fixed top-4 right-4 z-50 max-w-sm w-full drop-shadow-lg">
+          {actionError && (
+            <AlertBanner variant="error" message={actionError} onClose={() => setActionError(null)} />
+          )}
+          {actionSuccess && (
+            <AlertBanner variant="success" message={actionSuccess} onClose={() => setActionSuccess(null)} />
+          )}
+        </div>
+      )}
+
+      <div className="mb-4">
+        <h1 className="text-2xl md:text-3xl text-gray-800 dark:text-gray-100 font-bold">
+          Monitoreo
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Registro de errores automáticos y reportes de usuarios.
+        </p>
+      </div>
+
+      {/* Tabs */}
+      <div className="border-b border-gray-200 dark:border-gray-700">
+        <nav className="-mb-px flex gap-6">
+          {(["errores", "reportes"] as Tab[]).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              onClick={() => setActiveTab(tab)}
+              className={`pb-3 text-sm font-medium border-b-2 transition-colors capitalize ${
+                activeTab === tab
+                  ? "border-gray-900 text-gray-900 dark:border-gray-100 dark:text-gray-100"
+                  : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              }`}
+            >
+              {tab === "errores" ? "Errores automáticos" : "Reportes de usuarios"}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Errores tab */}
+      {activeTab === "errores" && (
+        <div className="space-y-4">
+          <div className="flex flex-wrap gap-3">
+            <SearchInput
+              className="w-full sm:w-64"
+              placeholder="Buscar por request ID"
+              value={erroresFilters.requestId}
+              onChange={(v) => setErrorFilter("requestId", v)}
+            />
+            <input
+              type="date"
+              className="form-input w-full sm:w-44"
+              value={erroresFilters.desde}
+              onChange={(e) => setErrorFilter("desde", e.target.value)}
+              aria-label="Desde"
+            />
+            <input
+              type="date"
+              className="form-input w-full sm:w-44"
+              value={erroresFilters.hasta}
+              onChange={(e) => setErrorFilter("hasta", e.target.value)}
+              aria-label="Hasta"
+            />
+          </div>
+
+          {erroresError && !erroresLoading && (
+            <AlertBanner variant="error" message={erroresError} onClose={() => {}} />
+          )}
+
+          <div className="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700">
+            <table className="w-full text-sm text-left">
+              <thead className="bg-gray-50 dark:bg-gray-800/60 text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                <tr>
+                  <th className="px-4 py-3">Request ID</th>
+                  <th className="px-4 py-3">Método</th>
+                  <th className="px-4 py-3">Ruta</th>
+                  <th className="px-4 py-3">Código</th>
+                  <th className="px-4 py-3">Tipo</th>
+                  <th className="px-4 py-3">Detalle</th>
+                  <th className="px-4 py-3">Fecha</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700/60">
+                {erroresLoading ? (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-8 text-center text-gray-400">
+                      Cargando...
+                    </td>
+                  </tr>
+                ) : errores.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-8 text-center text-gray-400">
+                      No hay registros.
+                    </td>
+                  </tr>
+                ) : (
+                  errores.map((e) => (
+                    <tr key={e.id} className="bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                      <td className="px-4 py-3 font-mono text-xs text-gray-500 dark:text-gray-400 max-w-[12rem] truncate" title={e.requestId}>
+                        {e.requestId}
+                      </td>
+                      <td className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                        {e.metodo ?? "—"}
+                      </td>
+                      <td className="px-4 py-3 text-gray-600 dark:text-gray-400 max-w-[14rem] truncate" title={e.ruta ?? ""}>
+                        {e.ruta ?? "—"}
+                      </td>
+                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                        {e.statusCode ?? "—"}
+                      </td>
+                      <td className="px-4 py-3 text-gray-600 dark:text-gray-400 max-w-[10rem] truncate" title={e.errorType ?? ""}>
+                        {e.errorType ?? "—"}
+                      </td>
+                      <td className="px-4 py-3 text-gray-600 dark:text-gray-400 max-w-[16rem] truncate" title={e.detalle ?? ""}>
+                        {e.detalle ?? "—"}
+                      </td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {formatDate(e.createdAt)}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-sm text-gray-500 dark:text-gray-400 mb-3 sm:mb-0">
+              Página {erroresCurrentPage} de {erroresTotalPages}
+            </div>
+            <Pagination
+              currentPage={erroresCurrentPage}
+              totalPages={erroresTotalPages}
+              onPageChange={setErrorPage}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Reportes tab */}
+      {activeTab === "reportes" && (
+        <div className="space-y-4">
+          <div className="flex flex-wrap gap-3">
+            <SearchInput
+              className="w-full sm:w-64"
+              placeholder="Buscar por request ID"
+              value={reportesFilters.requestId}
+              onChange={(v) => setReporteFilter("requestId", v)}
+            />
+            <select
+              className="form-select w-full sm:w-48"
+              value={reportesFilters.estado}
+              onChange={(e) => setReporteFilter("estado", e.target.value)}
+            >
+              {ESTADO_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+            <input
+              type="date"
+              className="form-input w-full sm:w-44"
+              value={reportesFilters.desde}
+              onChange={(e) => setReporteFilter("desde", e.target.value)}
+              aria-label="Desde"
+            />
+            <input
+              type="date"
+              className="form-input w-full sm:w-44"
+              value={reportesFilters.hasta}
+              onChange={(e) => setReporteFilter("hasta", e.target.value)}
+              aria-label="Hasta"
+            />
+          </div>
+
+          {reportesError && !reportesLoading && (
+            <AlertBanner variant="error" message={reportesError} onClose={() => {}} />
+          )}
+
+          <div className="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700">
+            <table className="w-full text-sm text-left">
+              <thead className="bg-gray-50 dark:bg-gray-800/60 text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                <tr>
+                  <th className="px-4 py-3">ID</th>
+                  <th className="px-4 py-3">Descripción</th>
+                  <th className="px-4 py-3">URL</th>
+                  <th className="px-4 py-3">Request ID</th>
+                  <th className="px-4 py-3">Estado</th>
+                  <th className="px-4 py-3">Fecha</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700/60">
+                {reportesLoading ? (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-8 text-center text-gray-400">
+                      Cargando...
+                    </td>
+                  </tr>
+                ) : reportes.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-8 text-center text-gray-400">
+                      No hay reportes.
+                    </td>
+                  </tr>
+                ) : (
+                  reportes.map((r) => (
+                    <tr key={r.id} className="bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{r.id}</td>
+                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300 max-w-[16rem] truncate" title={r.descripcion}>
+                        {r.descripcion}
+                      </td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400 max-w-[12rem] truncate" title={r.url ?? ""}>
+                        {r.url ?? "—"}
+                      </td>
+                      <td className="px-4 py-3 font-mono text-xs text-gray-500 dark:text-gray-400 max-w-[10rem] truncate" title={r.requestId ?? ""}>
+                        {r.requestId ?? "—"}
+                      </td>
+                      <td className="px-4 py-3">
+                        <select
+                          className={`text-xs font-medium px-2 py-1 rounded-full border-0 cursor-pointer ${ESTADO_COLORS[r.estado]}`}
+                          value={r.estado}
+                          disabled={updatingId === r.id}
+                          onChange={(e) => handleEstadoChange(r.id, e.target.value as EstadoReporte)}
+                          aria-label={`Estado del reporte ${r.id}`}
+                        >
+                          {(["NUEVO", "VISTO", "RESUELTO"] as EstadoReporte[]).map((s) => (
+                            <option key={s} value={s}>
+                              {ESTADO_LABELS[s]}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {formatDate(r.createdAt)}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-sm text-gray-500 dark:text-gray-400 mb-3 sm:mb-0">
+              Página {reportesCurrentPage} de {reportesTotalPages}
+            </div>
+            <Pagination
+              currentPage={reportesCurrentPage}
+              totalPages={reportesTotalPages}
+              onPageChange={setReportePage}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import ReportModal from "@/components/ui/report-modal";
+
+type Props = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ErrorBoundary({ error, reset }: Props) {
+  const [reportOpen, setReportOpen] = useState(false);
+
+  const initialDesc = error.message
+    ? `Error: ${error.message}${error.digest ? ` (digest: ${error.digest})` : ""}`
+    : "";
+
+  return (
+    <>
+      <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 text-center">
+        <div className="max-w-md space-y-4">
+          <div className="text-5xl" aria-hidden>
+            ⚠️
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Algo salió mal
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Ocurrió un error inesperado en esta sección. Puedes intentar nuevamente o reportar el
+            problema para que lo revisemos.
+          </p>
+          {error.digest && (
+            <p className="text-xs font-mono text-gray-400 dark:text-gray-500">
+              ref: {error.digest}
+            </p>
+          )}
+          <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2">
+            <button
+              type="button"
+              onClick={reset}
+              className="btn bg-gray-900 text-gray-100 hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-800 dark:hover:bg-white"
+            >
+              Reintentar
+            </button>
+            <button
+              type="button"
+              onClick={() => setReportOpen(true)}
+              className="btn border-gray-200 dark:border-gray-700/60 text-gray-700 dark:text-gray-200 hover:border-gray-300 dark:hover:border-gray-600"
+            >
+              Reportar problema
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <ReportModal
+        open={reportOpen}
+        onClose={() => setReportOpen(false)}
+        initialDescripcion={initialDesc}
+      />
+    </>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+type Props = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: Props) {
+  return (
+    <html lang="es">
+      <body>
+        <div
+          style={{
+            display: "flex",
+            minHeight: "100vh",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "1rem",
+            textAlign: "center",
+            fontFamily: "system-ui, sans-serif",
+          }}
+        >
+          <div style={{ maxWidth: "28rem" }}>
+            <p style={{ fontSize: "3rem", marginBottom: "1rem" }} aria-hidden>
+              ⚠️
+            </p>
+            <h1 style={{ fontSize: "1.5rem", fontWeight: 700, marginBottom: "0.5rem" }}>
+              Error crítico
+            </h1>
+            <p style={{ color: "#6b7280", fontSize: "0.875rem", marginBottom: "1rem" }}>
+              Ocurrió un error inesperado. Por favor recarga la página o intenta de nuevo.
+            </p>
+            {error.digest && (
+              <p
+                style={{
+                  fontFamily: "monospace",
+                  fontSize: "0.75rem",
+                  color: "#9ca3af",
+                  marginBottom: "1rem",
+                }}
+              >
+                ref: {error.digest}
+              </p>
+            )}
+            <button
+              type="button"
+              onClick={reset}
+              style={{
+                padding: "0.5rem 1.25rem",
+                backgroundColor: "#111827",
+                color: "#fff",
+                border: "none",
+                borderRadius: "0.5rem",
+                cursor: "pointer",
+                fontSize: "0.875rem",
+              }}
+            >
+              Reintentar
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/components/icons/sidebar-icons.tsx
+++ b/components/icons/sidebar-icons.tsx
@@ -8,6 +8,7 @@ import {
   UploadCloud,
   FolderKanban,
   History,
+  ShieldAlert,
 } from "lucide-react";
 
 export const SidebarIcons = {
@@ -20,6 +21,7 @@ export const SidebarIcons = {
   cargaMasiva: UploadCloud,
   catalogos: FolderKanban,
   miHistorial: History,
+  monitoreo: ShieldAlert,
 };
 
 export type SidebarIconKey = keyof typeof SidebarIcons;

--- a/components/ui/report-button.tsx
+++ b/components/ui/report-button.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState } from "react";
+import { MessageSquareWarning } from "lucide-react";
+import ReportModal from "@/components/ui/report-modal";
+
+export default function ReportButton() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        title="Reportar un problema"
+        aria-label="Reportar un problema"
+        className="fixed bottom-6 right-6 z-40 flex items-center justify-center w-12 h-12 rounded-full bg-gray-900 text-white shadow-lg hover:bg-gray-700 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white transition-colors"
+      >
+        <MessageSquareWarning className="w-5 h-5" />
+      </button>
+
+      <ReportModal open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}

--- a/components/ui/report-modal.tsx
+++ b/components/ui/report-modal.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { Fragment, useState } from "react";
+import { Dialog, Transition } from "@headlessui/react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { reportarProblema } from "@/lib/api/monitoreo";
+import { getLastRequestId } from "@/lib/api/client";
+import AlertBanner from "@/components/ui/alert-banner";
+
+const MAX_DESC = 2000;
+
+const schema = z.object({
+  descripcion: z
+    .string()
+    .min(1, "La descripción es requerida.")
+    .max(MAX_DESC, `La descripción no puede superar los ${MAX_DESC} caracteres.`),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  initialDescripcion?: string;
+};
+
+export default function ReportModal({ open, onClose, initialDescripcion = "" }: Props) {
+  const [submitStatus, setSubmitStatus] = useState<"idle" | "success" | "error">("idle");
+  const [submitMessage, setSubmitMessage] = useState("");
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { descripcion: initialDescripcion },
+  });
+
+  const descripcion = watch("descripcion");
+
+  const handleClose = () => {
+    if (isSubmitting) return;
+    reset({ descripcion: initialDescripcion });
+    setSubmitStatus("idle");
+    setSubmitMessage("");
+    onClose();
+  };
+
+  const onSubmit = async (values: FormValues) => {
+    setSubmitStatus("idle");
+    try {
+      await reportarProblema({
+        descripcion: values.descripcion,
+        requestId: getLastRequestId() ?? undefined,
+        url: typeof window !== "undefined" ? window.location.href : undefined,
+        userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+      });
+      setSubmitStatus("success");
+      setSubmitMessage("Tu reporte fue enviado. Gracias por ayudarnos a mejorar.");
+      reset({ descripcion: "" });
+    } catch (err: unknown) {
+      setSubmitStatus("error");
+      setSubmitMessage(
+        err instanceof Error ? err.message : "No se pudo enviar el reporte. Intenta nuevamente."
+      );
+    }
+  };
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={handleClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-900/40 backdrop-blur-sm" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-200"
+              enterFrom="opacity-0 translate-y-2 scale-95"
+              enterTo="opacity-100 translate-y-0 scale-100"
+              leave="ease-in duration-150"
+              leaveFrom="opacity-100 translate-y-0 scale-100"
+              leaveTo="opacity-0 translate-y-2 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-lg transform overflow-hidden rounded-xl bg-white dark:bg-gray-800 text-left align-middle shadow-xl transition-all border border-gray-200 dark:border-gray-700/60">
+                <div className="px-6 py-5 space-y-1">
+                  <Dialog.Title className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                    Reportar un problema
+                  </Dialog.Title>
+                  <Dialog.Description className="text-sm text-gray-500 dark:text-gray-400">
+                    Describe lo que ocurrió. Tu reporte ayuda a mejorar el sistema.
+                  </Dialog.Description>
+                </div>
+
+                <form onSubmit={handleSubmit(onSubmit)} noValidate>
+                  <div className="px-6 pb-4 space-y-4">
+                    {submitStatus !== "idle" && (
+                      <AlertBanner
+                        variant={submitStatus}
+                        message={submitMessage}
+                        onClose={() => setSubmitStatus("idle")}
+                      />
+                    )}
+
+                    <div>
+                      <label
+                        htmlFor="report-descripcion"
+                        className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                      >
+                        Descripción <span className="text-rose-500">*</span>
+                      </label>
+                      <textarea
+                        id="report-descripcion"
+                        rows={5}
+                        className={`form-textarea w-full resize-none ${
+                          errors.descripcion
+                            ? "border-rose-400 focus:border-rose-500 focus:ring-rose-500"
+                            : ""
+                        }`}
+                        placeholder="¿Qué ocurrió? Describe el problema con el mayor detalle posible."
+                        {...register("descripcion")}
+                      />
+                      <div className="flex justify-between items-start mt-1">
+                        <span className="text-xs text-rose-600 dark:text-rose-400">
+                          {errors.descripcion?.message ?? ""}
+                        </span>
+                        <span
+                          className={`text-xs tabular-nums ${
+                            descripcion.length > MAX_DESC
+                              ? "text-rose-600 dark:text-rose-400"
+                              : "text-gray-400 dark:text-gray-500"
+                          }`}
+                        >
+                          {descripcion.length}/{MAX_DESC}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700/60 flex justify-end gap-2 bg-gray-50/60 dark:bg-gray-900/30">
+                    <button
+                      type="button"
+                      className="btn border-gray-200 dark:border-gray-700/60 text-gray-700 dark:text-gray-200 hover:border-gray-300 dark:hover:border-gray-600"
+                      onClick={handleClose}
+                      disabled={isSubmitting}
+                    >
+                      Cancelar
+                    </button>
+                    <button
+                      type="submit"
+                      className="btn bg-gray-900 text-gray-100 hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-800 dark:hover:bg-white disabled:opacity-60 disabled:cursor-not-allowed"
+                      disabled={isSubmitting}
+                    >
+                      {isSubmitting ? "Enviando..." : "Enviar reporte"}
+                    </button>
+                  </div>
+                </form>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -10,6 +10,11 @@ import { authDebugLog, describeToken } from "@/lib/auth/debug";
 
 export type ApiEnvelope<T> = ApiResponse<T>;
 
+let lastRequestId: string | null = null;
+export function getLastRequestId() {
+  return lastRequestId;
+}
+
 export class ApiError extends Error {
   status: number;
   problem?: ProblemDetails | null;
@@ -247,6 +252,9 @@ export async function apiFetch<T>(
       res = await request(token);
     }
   }
+
+  const rid = res.headers.get("X-Request-Id");
+  if (rid) lastRequestId = rid;
 
   const payload = (await res.json().catch(() => null)) as
     | ApiResponse<T>

--- a/lib/api/monitoreo.ts
+++ b/lib/api/monitoreo.ts
@@ -1,0 +1,62 @@
+import { apiFetch } from "@/lib/api/client";
+import type {
+  RegistroError,
+  ReporteProblema,
+  EstadoReporte,
+  CrearReportePayload,
+  RegistroErrorFiltros,
+  ReporteFiltros,
+} from "@/types/monitoreo";
+import type { ApiResponse } from "@/types/api-response";
+
+export async function reportarProblema(
+  dto: CrearReportePayload
+): Promise<ApiResponse<ReporteProblema>> {
+  return apiFetch<ReporteProblema>("/monitoreo/reporte", {
+    method: "POST",
+    body: JSON.stringify(dto),
+  });
+}
+
+export async function getRegistrosError(
+  filtros: RegistroErrorFiltros = {}
+): Promise<ApiResponse<RegistroError[]>> {
+  const params = new URLSearchParams();
+  if (filtros.page) params.set("page", String(filtros.page));
+  if (filtros.limit) params.set("limit", String(filtros.limit));
+  if (filtros.requestId) params.set("requestId", filtros.requestId);
+  if (filtros.desde) params.set("desde", filtros.desde);
+  if (filtros.hasta) params.set("hasta", filtros.hasta);
+
+  const qs = params.toString();
+  return apiFetch<RegistroError[]>(qs ? `/monitoreo/errores?${qs}` : "/monitoreo/errores", {
+    method: "GET",
+  });
+}
+
+export async function getReportesProblema(
+  filtros: ReporteFiltros = {}
+): Promise<ApiResponse<ReporteProblema[]>> {
+  const params = new URLSearchParams();
+  if (filtros.page) params.set("page", String(filtros.page));
+  if (filtros.limit) params.set("limit", String(filtros.limit));
+  if (filtros.requestId) params.set("requestId", filtros.requestId);
+  if (filtros.estado) params.set("estado", filtros.estado);
+  if (filtros.desde) params.set("desde", filtros.desde);
+  if (filtros.hasta) params.set("hasta", filtros.hasta);
+
+  const qs = params.toString();
+  return apiFetch<ReporteProblema[]>(qs ? `/monitoreo/reportes?${qs}` : "/monitoreo/reportes", {
+    method: "GET",
+  });
+}
+
+export async function actualizarEstadoReporte(
+  id: number,
+  estado: EstadoReporte
+): Promise<ApiResponse<ReporteProblema>> {
+  return apiFetch<ReporteProblema>(`/monitoreo/reportes/${id}/estado`, {
+    method: "PATCH",
+    body: JSON.stringify({ estado }),
+  });
+}

--- a/lib/navigation/sidebar.config.ts
+++ b/lib/navigation/sidebar.config.ts
@@ -125,6 +125,14 @@ export const SIDEBAR_ITEMS: SidebarItem[] = [
     roles: ["SUPER_ADMIN", "ADMIN"],
   },
   {
+    type: "link",
+    label: "Monitoreo",
+    href: "/monitoreo",
+    segment: "monitoreo",
+    icon: "monitoreo",
+    roles: ADMIN_ACCESS_ROLES,
+  },
+  {
     type: "group",
     label: "Catálogos",
     segment: "catalogos",

--- a/types/monitoreo.ts
+++ b/types/monitoreo.ts
@@ -1,0 +1,53 @@
+export type EstadoReporte = "NUEVO" | "VISTO" | "RESUELTO";
+
+export type RegistroError = {
+  id: number;
+  requestId: string;
+  metodo: string | null;
+  ruta: string | null;
+  statusCode: number | null;
+  errorType: string | null;
+  titulo: string | null;
+  detalle: string | null;
+  userAgent: string | null;
+  usuarioId: number | null;
+  durationMs: number | null;
+  contexto: Record<string, unknown> | null;
+  createdAt: string;
+};
+
+export type ReporteProblema = {
+  id: number;
+  descripcion: string;
+  requestId: string | null;
+  url: string | null;
+  userAgent: string | null;
+  usuarioId: number | null;
+  estado: EstadoReporte;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CrearReportePayload = {
+  descripcion: string;
+  requestId?: string | null;
+  url?: string;
+  userAgent?: string;
+};
+
+export type RegistroErrorFiltros = {
+  page?: number;
+  limit?: number;
+  requestId?: string;
+  desde?: string;
+  hasta?: string;
+};
+
+export type ReporteFiltros = {
+  page?: number;
+  limit?: number;
+  requestId?: string;
+  estado?: EstadoReporte | "";
+  desde?: string;
+  hasta?: string;
+};


### PR DESCRIPTION
## What

Implements the frontend slice of the `monitoreo-errores` observability feature (backend slice merged in PR #67).

## New files

| File | Purpose |
|------|---------|
| `types/monitoreo.ts` | Types for RegistroError, ReporteProblema, EstadoReporte and payload/filter shapes |
| `lib/api/monitoreo.ts` | API functions: reportarProblema, getRegistrosError, getReportesProblema, actualizarEstadoReporte |
| `lib/api/client.ts` | Captures X-Request-Id response header via module-level lastRequestId + getLastRequestId() |
| `app/error.tsx` | Segment error boundary: retry + report action |
| `app/global-error.tsx` | Root error boundary with own html/body (Next.js requirement) |
| `components/ui/report-modal.tsx` | Headless UI dialog, RHF+Zod, auto-captures url/requestId/userAgent |
| `components/ui/report-button.tsx` | Floating button (fixed bottom-right z-40) that opens the modal |
| `app/(app)/layout.tsx` | Mounts ReportButton inside the authenticated layout |
| `app/(app)/monitoreo/page.tsx` | Admin page: tabs for error records and user reports, filters, inline estado transitions |
| `components/icons/sidebar-icons.tsx` | ShieldAlert icon for monitoreo sidebar entry |
| `lib/navigation/sidebar.config.ts` | Monitoreo sidebar link gated to ADMIN_ACCESS_ROLES |

## Why

Adds frontend resilience (error boundaries), user-facing problem reporting, and the admin monitoring view. Correlates frontend reports to backend error records via `requestId` (from `X-Request-Id` response header).

## How to test

1. Start backend (PR #67 merged) and frontend.
2. Trigger a 5xx API error — note the `X-Request-Id` in the response.
3. Click the floating report button on any authenticated page → fill description → submit.
4. As admin, go to `/monitoreo` → Reportes tab → verify the report row shows the same `requestId`.
5. Navigate to Errores tab → filter by that `requestId` → see the auto-captured RegistroError row.
6. Test estado transitions: change NUEVO → VISTO → RESUELTO and back (all directions are valid by design).
7. Throw an intentional render error in dev → verify `app/error.tsx` boundary appears → click "Reportar problema" → modal opens pre-filled with error message.

## Depends on

Backend PR #67 (merged) — endpoints `/api/v1/monitoreo/*` must be live.