### PR TITLE
fix(avales): correcciones solicitud de aval — fecha nacimiento, validación entrenador mínimo, entrenador texto libre

### DIFF
--- a/app/(app)/avales/_components/aval-document-preview.tsx
+++ b/app/(app)/avales/_components/aval-document-preview.tsx
@@ -25,7 +25,7 @@ type FormData = {
     observacion?: string;
     rol?: string;
   }>;
-  entrenadores: Array<{ id: number; nombre: string }>;
+  entrenadores: Array<{ id: number; nombre: string; esTextoLibre?: boolean }>;
   fechaEmision?: string;
   fechaHoraSalida: string;
   fechaHoraRetorno: string;

--- a/app/(app)/avales/_components/aval-document-preview.tsx
+++ b/app/(app)/avales/_components/aval-document-preview.tsx
@@ -54,25 +54,26 @@ type AvalDocumentPreviewProps = {
 
 export type AvalPreviewFormData = FormData;
 
-const PREVIEW_MONTHS = [
-  "enero",
-  "febrero",
-  "marzo",
-  "abril",
-  "mayo",
-  "junio",
-  "julio",
-  "agosto",
-  "septiembre",
-  "octubre",
-  "noviembre",
-  "diciembre",
+const PREVIEW_MONTHS_ABBR = [
+  "ENE",
+  "FEB",
+  "MAR",
+  "ABR",
+  "MAY",
+  "JUN",
+  "JUL",
+  "AGO",
+  "SEP",
+  "OCT",
+  "NOV",
+  "DIC",
 ];
 
 function formatPreviewBirthDate(value?: string | null) {
   const parts = getCalendarDateParts(value);
   if (!parts) return "-";
-  return `${parts.day} ${PREVIEW_MONTHS[parts.month - 1]} ${parts.year}`;
+  const dia = String(parts.day).padStart(2, "0");
+  return `${dia}/${PREVIEW_MONTHS_ABBR[parts.month - 1]}/${parts.year}`;
 }
 
 export default function AvalDocumentPreview({

--- a/app/(app)/avales/_components/paso-01-deportistas.tsx
+++ b/app/(app)/avales/_components/paso-01-deportistas.tsx
@@ -43,7 +43,7 @@ type FormData = {
     rol?: string;
     modalidadParticipacion?: ModalidadParticipacion;
   }>;
-  entrenadores: Array<{ id: number; nombre: string }>;
+  entrenadores: Array<{ id: number; nombre: string; esTextoLibre?: boolean }>;
   fechaEmision?: string;
   fechaHoraSalida: string;
   fechaHoraRetorno: string;
@@ -69,7 +69,7 @@ type SelectedDeportista = Deportista & {
   rol?: string;
   modalidadParticipacion?: ModalidadParticipacion;
 };
-type SelectedEntrenador = User;
+type SelectedEntrenador = User | { id: number; nombre: string; apellido: string; cedula?: undefined; esTextoLibre: true };
 
 function formatDeportistaNombre(
   deportista: Pick<Deportista, "nombres" | "apellidos">
@@ -148,10 +148,19 @@ export default function Paso01Deportistas({
   const [entrenadores, setEntrenadores] = useState<User[]>([]);
   const [loadingEntrenadores, setLoadingEntrenadores] = useState(false);
   const [entrenadoresFocused, setEntrenadoresFocused] = useState(false);
+  const freeTextIdCounterRef = useRef(-1);
   const [selectedEntrenadores, setSelectedEntrenadores] = useState<
     SelectedEntrenador[]
   >(() =>
     (formData.entrenadores ?? []).map((e) => {
+      if (e.esTextoLibre) {
+        return {
+          id: e.id,
+          nombre: e.nombre,
+          apellido: "",
+          esTextoLibre: true as const,
+        };
+      }
       const [nombre = "", ...apellidoParts] = (e.nombre ?? "").split(" ");
       return {
         id: e.id,
@@ -160,6 +169,7 @@ export default function Paso01Deportistas({
       } as SelectedEntrenador;
     }),
   );
+  const [freeTextEntrenadorNombre, setFreeTextEntrenadorNombre] = useState("");
 
   const [principalEntrenadorId, setPrincipalEntrenadorId] = useState<
     number | null
@@ -219,7 +229,10 @@ export default function Paso01Deportistas({
       })),
       entrenadores: orderedEntrenadores.map((e) => ({
         id: e.id,
-        nombre: `${e.nombre} ${e.apellido}`.trim(),
+        nombre: "esTextoLibre" in e && e.esTextoLibre
+          ? e.nombre
+          : `${e.nombre} ${e.apellido ?? ""}`.trim(),
+        esTextoLibre: "esTextoLibre" in e && e.esTextoLibre ? true : undefined,
       })),
       fechaEmision,
       tipoAval,
@@ -242,7 +255,6 @@ export default function Paso01Deportistas({
     const isEntrenador =
       getNormalizedRoles(user).includes("ENTRENADOR") && !isAdminUser(user);
     if (!isEntrenador) return;
-    if (totalEntrenadoresRequeridos <= 0) return;
 
     const alreadySelected = selectedEntrenadores.some((e) => e.id === user.id);
     if (alreadySelected) {
@@ -365,7 +377,10 @@ export default function Paso01Deportistas({
 
   const handleAddEntrenador = (entrenador: User) => {
     const alreadySelected = selectedEntrenadores.some((e) => e.id === entrenador.id);
-    if (alreadySelected || selectedEntrenadores.length >= totalEntrenadoresRequeridos) {
+    const limitReached =
+      totalEntrenadoresRequeridos > 0 &&
+      selectedEntrenadores.length >= totalEntrenadoresRequeridos;
+    if (alreadySelected || limitReached) {
       return;
     }
 
@@ -374,6 +389,24 @@ export default function Paso01Deportistas({
       setPrincipalEntrenadorId(entrenador.id);
     }
     setSearchEntrenadores("");
+  };
+
+  const handleAddEntrenadorTextoLibre = () => {
+    const nombre = freeTextEntrenadorNombre.trim();
+    if (!nombre) return;
+    const freeTextId = freeTextIdCounterRef.current;
+    freeTextIdCounterRef.current -= 1;
+    const entry: SelectedEntrenador = {
+      id: freeTextId,
+      nombre,
+      apellido: "",
+      esTextoLibre: true,
+    };
+    setSelectedEntrenadores((prev) => [...prev, entry]);
+    if (principalEntrenadorId == null) {
+      setPrincipalEntrenadorId(freeTextId);
+    }
+    setFreeTextEntrenadorNombre("");
   };
 
   const handleRemoveEntrenador = (entrenadorId: number) => {
@@ -397,7 +430,10 @@ export default function Paso01Deportistas({
       return;
     }
 
-    if (selectedEntrenadores.length !== totalEntrenadoresRequeridos) {
+    if (
+      totalEntrenadoresRequeridos > 0 &&
+      selectedEntrenadores.length !== totalEntrenadoresRequeridos
+    ) {
       setError(
         `Debes seleccionar exactamente ${totalEntrenadoresRequeridos} ${
           totalEntrenadoresRequeridos === 1 ? "entrenador" : "entrenadores"
@@ -615,50 +651,52 @@ export default function Paso01Deportistas({
   };
 
   const renderEntrenadorSearch = () => {
-    if (totalEntrenadoresRequeridos === 0) {
-      return (
-        <div className="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            Este evento no requiere entrenadores para esta delegación.
-          </p>
-        </div>
-      );
-    }
+    const dropdownLimitReached =
+      totalEntrenadoresRequeridos > 0 &&
+      selectedEntrenadores.length >= totalEntrenadoresRequeridos;
 
     return (
       <div>
-        <div className="flex items-center justify-between mb-2">
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-            Entrenadores
-          </label>
-          <span
-            className={`text-sm font-medium ${
-              selectedEntrenadores.length === totalEntrenadoresRequeridos
-                ? "text-emerald-600 dark:text-emerald-400"
-                : selectedEntrenadores.length > totalEntrenadoresRequeridos
-                ? "text-rose-600 dark:text-rose-400"
-                : "text-gray-500 dark:text-gray-400"
-            }`}
-          >
-            {selectedEntrenadores.length} / {totalEntrenadoresRequeridos}
-          </span>
-        </div>
-        <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-          El evento requiere {totalEntrenadoresRequeridos}{" "}
-          {totalEntrenadoresRequeridos === 1 ? "entrenador" : "entrenadores"}.
-        </p>
+        {totalEntrenadoresRequeridos > 0 && (
+          <div className="flex items-center justify-between mb-2">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Entrenadores
+            </label>
+            <span
+              className={`text-sm font-medium ${
+                selectedEntrenadores.length === totalEntrenadoresRequeridos
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : selectedEntrenadores.length > totalEntrenadoresRequeridos
+                  ? "text-rose-600 dark:text-rose-400"
+                  : "text-gray-500 dark:text-gray-400"
+              }`}
+            >
+              {selectedEntrenadores.length} / {totalEntrenadoresRequeridos}
+            </span>
+          </div>
+        )}
+        {totalEntrenadoresRequeridos > 0 ? (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+            El evento requiere {totalEntrenadoresRequeridos}{" "}
+            {totalEntrenadoresRequeridos === 1 ? "entrenador" : "entrenadores"}.
+          </p>
+        ) : (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+            Asigna al menos un entrenador responsable para continuar.
+          </p>
+        )}
 
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
           <input
             type="text"
             className="form-input w-full pl-10 pr-10"
-            placeholder="Buscar entrenador..."
+            placeholder="Buscar entrenador registrado..."
             value={searchEntrenadores}
             onChange={(e) => setSearchEntrenadores(e.target.value)}
             onFocus={() => setEntrenadoresFocused(true)}
             onBlur={() => setTimeout(() => setEntrenadoresFocused(false), 150)}
-            disabled={selectedEntrenadores.length >= totalEntrenadoresRequeridos}
+            disabled={dropdownLimitReached}
           />
           {searchEntrenadores.trim() && (
             <button
@@ -686,9 +724,7 @@ export default function Paso01Deportistas({
                   const alreadySelected = selectedEntrenadores.some(
                     (e) => e.id === entrenador.id
                   );
-                  const limitReached =
-                    selectedEntrenadores.length >= totalEntrenadoresRequeridos;
-                  const isDisabled = alreadySelected || limitReached;
+                  const isDisabled = alreadySelected || dropdownLimitReached;
 
                   return (
                     <button
@@ -726,46 +762,90 @@ export default function Paso01Deportistas({
           )}
         </div>
 
+        {!dropdownLimitReached && (
+          <div className="mt-3">
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+              ¿El entrenador no está en el sistema?
+            </p>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                className="form-input flex-1"
+                placeholder="Nombre completo del entrenador"
+                value={freeTextEntrenadorNombre}
+                onChange={(e) => setFreeTextEntrenadorNombre(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    handleAddEntrenadorTextoLibre();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                onClick={handleAddEntrenadorTextoLibre}
+                disabled={!freeTextEntrenadorNombre.trim()}
+                className="px-3 py-2 text-sm font-medium text-white bg-emerald-600 hover:bg-emerald-700 disabled:opacity-40 disabled:cursor-not-allowed rounded-md"
+              >
+                Agregar
+              </button>
+            </div>
+          </div>
+        )}
+
         {selectedEntrenadores.length > 0 && (
           <div className="mt-3 space-y-2">
-            {selectedEntrenadores.map((entrenador) => (
-              <div
-                key={entrenador.id}
-                className="flex items-start gap-2 bg-white dark:bg-gray-700 text-sm font-medium text-gray-800 dark:text-gray-100 p-2 rounded-md border border-gray-200 dark:border-gray-600"
-              >
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium text-sm">
-                    {entrenador.nombre} {entrenador.apellido}
-                  </p>
-                  <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
-                    {entrenador.cedula}
-                  </p>
-                  <div className="mt-1">
-                    <button
-                      type="button"
-                      onClick={() => setPrincipalEntrenadorId(entrenador.id)}
-                      className={`text-[11px] font-semibold ${
-                        principalEntrenadorId === entrenador.id
-                          ? "text-emerald-600 dark:text-emerald-400"
-                          : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-                      }`}
-                    >
-                      {principalEntrenadorId === entrenador.id
-                        ? "Principal"
-                        : "Marcar como principal"}
-                    </button>
-                  </div>
-                </div>
-
-                <button
-                  type="button"
-                  onClick={() => handleRemoveEntrenador(entrenador.id)}
-                  className="text-rose-600 hover:text-rose-700 dark:text-rose-400 dark:hover:text-rose-300 p-1"
+            {selectedEntrenadores.map((entrenador) => {
+              const isFreeText = "esTextoLibre" in entrenador && entrenador.esTextoLibre;
+              const displayName = isFreeText
+                ? entrenador.nombre
+                : `${entrenador.nombre} ${entrenador.apellido ?? ""}`.trim();
+              return (
+                <div
+                  key={entrenador.id}
+                  className="flex items-start gap-2 bg-white dark:bg-gray-700 text-sm font-medium text-gray-800 dark:text-gray-100 p-2 rounded-md border border-gray-200 dark:border-gray-600"
                 >
-                  <X className="w-5 h-5" />
-                </button>
-              </div>
-            ))}
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-sm">
+                      {displayName}
+                    </p>
+                    {!isFreeText && entrenador.cedula && (
+                      <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
+                        {entrenador.cedula}
+                      </p>
+                    )}
+                    {isFreeText && (
+                      <p className="text-[11px] text-amber-600 dark:text-amber-400 mt-0.5">
+                        No registrado en el sistema
+                      </p>
+                    )}
+                    <div className="mt-1">
+                      <button
+                        type="button"
+                        onClick={() => setPrincipalEntrenadorId(entrenador.id)}
+                        className={`text-[11px] font-semibold ${
+                          principalEntrenadorId === entrenador.id
+                            ? "text-emerald-600 dark:text-emerald-400"
+                            : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+                        }`}
+                      >
+                        {principalEntrenadorId === entrenador.id
+                          ? "Principal"
+                          : "Marcar como principal"}
+                      </button>
+                    </div>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveEntrenador(entrenador.id)}
+                    className="text-rose-600 hover:text-rose-700 dark:text-rose-400 dark:hover:text-rose-300 p-1"
+                  >
+                    <X className="w-5 h-5" />
+                  </button>
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/app/(app)/avales/_components/paso-01-deportistas.tsx
+++ b/app/(app)/avales/_components/paso-01-deportistas.tsx
@@ -430,6 +430,11 @@ export default function Paso01Deportistas({
       return;
     }
 
+    if (selectedEntrenadores.length === 0) {
+      setError("Debe asignar al menos un entrenador responsable.");
+      return;
+    }
+
     if (
       totalEntrenadoresRequeridos > 0 &&
       selectedEntrenadores.length !== totalEntrenadoresRequeridos
@@ -442,7 +447,7 @@ export default function Paso01Deportistas({
       return;
     }
 
-    if (selectedEntrenadores.length > 0 && principalEntrenadorId == null) {
+    if (principalEntrenadorId == null) {
       setError("Debes seleccionar un entrenador principal.");
       return;
     }

--- a/app/(app)/avales/_components/paso-04-presupuesto.tsx
+++ b/app/(app)/avales/_components/paso-04-presupuesto.tsx
@@ -50,7 +50,7 @@ type FormData = {
     rol?: string;
     modalidadParticipacion?: ModalidadParticipacion;
   }>;
-  entrenadores: Array<{ id: number; nombre: string }>;
+  entrenadores: Array<{ id: number; nombre: string; esTextoLibre?: boolean }>;
   fechaEmision?: string;
   fechaHoraSalida: string;
   fechaHoraRetorno: string;
@@ -351,7 +351,9 @@ export default function Paso04Presupuesto({
           modalidadParticipacion: d.modalidadParticipacion,
         })),
         entrenadores: formData.entrenadores.map((e, index) => ({
-          entrenadorId: e.id,
+          ...(e.esTextoLibre
+            ? { entrenadorNombre: e.nombre }
+            : { entrenadorId: e.id }),
           rol: index === 0 ? "ENTRENADOR PRINCIPAL" : "ENTRENADOR",
           esPrincipal: index === 0,
         })),

--- a/app/(fullscreen)/avales/[id]/crear-solicitud/page.tsx
+++ b/app/(fullscreen)/avales/[id]/crear-solicitud/page.tsx
@@ -45,7 +45,7 @@ type FormData = {
     rol?: string;
     modalidadParticipacion?: ModalidadParticipacion;
   }>;
-  entrenadores: Array<{ id: number; nombre: string }>;
+  entrenadores: Array<{ id: number; nombre: string; esTextoLibre?: boolean }>;
 
   // Paso 2: Logística
   fechaHoraSalida: string;

--- a/types/aval.ts
+++ b/types/aval.ts
@@ -351,7 +351,8 @@ export type DeportistaAvalDto = {
 };
 
 export type EntrenadorAvalDto = {
-  entrenadorId: number;
+  entrenadorId?: number;
+  entrenadorNombre?: string;
   rol: string;
   esPrincipal?: boolean;
 };


### PR DESCRIPTION
## Resumen

Este PR incluye tres correcciones sobre el flujo de creación de solicitud de aval (cluster A). Se complementa con el backend PR #68 para los ítems 3 y 16.

### Ítem 15 — Fecha de nacimiento en formato DD/MMM/AAAA (25/FEB/2026)

La previsualización del documento mostraba la fecha de nacimiento de los deportistas en formato incorrecto. Ahora se formatea como `25/FEB/2026` usando abreviaturas de mes en español mayúsculas, consistente con el resto del documento.

### Ítem 3 — Validación: al menos un entrenador responsable obligatorio

Se agrega una guarda absoluta en el `handleSubmit` del paso 1. Aunque el evento defina `numEntrenadoresHombres + numEntrenadoresMujeres = 0`, la solicitud no puede guardarse sin al menos un entrenador responsable asignado. El backend ya rechaza payloads con `entrenadores[]` vacío (`@ArrayMinSize(1)`). El mensaje de error mostrado es: _"Debe asignar al menos un entrenador responsable."_

### Ítem 16 — Entrenador responsable: default creador + opción de nombre libre no registrado

- El usuario que tiene rol `ENTRENADOR` sigue siendo auto-seleccionado como responsable principal al abrir el formulario (comportamiento previo preservado). El auto-select ahora también corre cuando `totalEntrenadoresRequeridos = 0`.
- Se agrega un campo de texto libre bajo el buscador de entrenadores registrados para ingresar el nombre de un entrenador que no está en el sistema.
- Al ensamblar el payload, los entrenadores registrados envían `entrenadorId`; los de texto libre envían `entrenadorNombre`. Nunca se envían ambos en la misma entrada, respetando el contrato del backend (PR #68).
- La previsualización del documento muestra correctamente el nombre del entrenador no registrado.
- `EntrenadorAvalDto` en `types/aval.ts` fue actualizado: `entrenadorId` y `entrenadorNombre` son ahora opcionales para admitir ambos casos.

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `app/(app)/avales/_components/paso-01-deportistas.tsx` | Tipo `SelectedEntrenador` con discriminador, UI de texto libre, guardia mínimo-1, auto-select sin límite de count |
| `app/(app)/avales/_components/paso-04-presupuesto.tsx` | Mapeo de payload: `entrenadorId` vs `entrenadorNombre` según `esTextoLibre` |
| `app/(app)/avales/_components/aval-document-preview.tsx` | Tipo `FormData.entrenadores` acepta `esTextoLibre?` |
| `app/(fullscreen)/avales/[id]/crear-solicitud/page.tsx` | Tipo `FormData.entrenadores` acepta `esTextoLibre?` |
| `types/aval.ts` | `EntrenadorAvalDto`: `entrenadorId` y `entrenadorNombre` opcionales |

## Plan de prueba

- [ ] Evento con `totalEntrenadoresRequeridos > 0`: flujo normal sigue funcionando
- [ ] Evento con `totalEntrenadoresRequeridos = 0`: intentar guardar sin entrenador muestra el error de mínimo-1
- [ ] Evento con `totalEntrenadoresRequeridos = 0`: asignar un entrenador registrado permite continuar
- [ ] Ingresar un nombre libre en el campo de texto libre y hacer clic en "Agregar": el entrenador aparece en la lista con la etiqueta "No registrado en el sistema"
- [ ] Al guardar, el payload contiene `entrenadorNombre` para el libre y `entrenadorId` para los registrados
- [ ] La previsualización muestra el nombre del entrenador libre correctamente
- [ ] Usuario con rol ENTRENADOR ve su nombre auto-seleccionado como principal
- [ ] `pnpm build` sin errores nuevos