### PR TITLE
fix(eventos): filtro disciplinas para PDA (item 4) + total presupuesto en edicion (item 7)

### DIFF
--- a/app/(app)/eventos/_components/use-evento-form.ts
+++ b/app/(app)/eventos/_components/use-evento-form.ts
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { ChangeEvent, DragEvent } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useFieldArray, useForm, useWatch } from "react-hook-form";
 
 import { ApiError } from "@/lib/api/client";
 import { getCatalog, getItemsPresupuestarios } from "@/lib/api/catalog";
@@ -65,7 +65,6 @@ export function useEventoForm({
     setError,
     setValue,
     getValues,
-    watch,
   } = useForm<EventoFormValues>({
     resolver: zodResolver(eventoSchema),
     defaultValues: initialValues,
@@ -120,7 +119,10 @@ export function useEventoForm({
     name: "eventoItems",
   });
 
-  const eventoItemsValues = watch("eventoItems") ?? [];
+  // Totales: useWatch (no watch()) para reflejar de forma fiable los valores del
+  // field array tras el reset() en edición. Con watch() el total quedaba en 0
+  // aunque los inputs de cada item sí mostraran su presupuesto (desync RHF).
+  const eventoItemsValues = useWatch({ control, name: "eventoItems" }) ?? [];
 
   const totalPresupuesto = useMemo(
     () =>

--- a/app/(app)/eventos/page.tsx
+++ b/app/(app)/eventos/page.tsx
@@ -11,7 +11,7 @@ import EventoCard from "./_components/evento-card";
 import Pagination from "@/components/ui/pagination";
 import UploadEventsExcelModal from "@/components/events/upload-excel-events-modal";
 import { useAuth } from "@/app/providers/auth-provider";
-import { getNormalizedRoles, isAdminUser, isDTMUser } from "@/lib/auth/access";
+import { getNormalizedRoles, isAdminUser, isDTMUser, isPdaUser } from "@/lib/auth/access";
 import { getDisciplinas } from "@/lib/api/catalog";
 import { listEventos, softDeleteEvento } from "@/lib/api/eventos";
 import type { CatalogItem } from "@/types/catalog";
@@ -35,6 +35,8 @@ export default function EventosPage() {
   const canManageEvents = isAdminUser(user);
   const isDTM = isDTMUser(user);
   const isEntrenador = userRoles.includes("ENTRENADOR") && !canManageEvents;
+  // El filtro de disciplina lo ven admins y PDA (item 4: PDA no tenía filtro en eventos).
+  const canFilterByDisciplina = canManageEvents || isPdaUser(user);
 
   const { filters, page, setFilter, setPage } = useUrlFilters("/eventos", {
     search: "",
@@ -83,13 +85,13 @@ export default function EventosPage() {
   }, [page, currentPage, setPage]);
 
   useEffect(() => {
-    if (!canManageEvents) return;
+    if (!canFilterByDisciplina) return;
     setDisciplinasLoading(true);
     getDisciplinas()
       .then((res) => setDisciplinas(res.data ?? []))
       .catch(() => setDisciplinas([]))
       .finally(() => setDisciplinasLoading(false));
-  }, [canManageEvents]);
+  }, [canFilterByDisciplina]);
 
   useEffect(() => {
     if (confirmOpen) return;
@@ -169,7 +171,7 @@ export default function EventosPage() {
                 </option>
               ))}
             </select>
-            {canManageEvents && !isDTM && (
+            {canFilterByDisciplina && !isDTM && (
               <select
                 className="form-select w-full sm:w-56"
                 value={filters.disciplinaId}


### PR DESCRIPTION
## Qué

Cluster B de los ítems de Xavier: bugs del dominio de eventos.

### Ítem 4 — Filtro de disciplinas para PDA
En `eventos/page.tsx`, el `<select>` de disciplina y el fetch de disciplinas estaban gateados a `canManageEvents` (solo admin), así que el rol **PDA no veía el filtro**. Se incluye a PDA vía `isPdaUser`. El backend ya soportaba `disciplinaId` — fue solo la guarda del frontend. **No requiere backend.**

### Ítem 7 — Total presupuesto en 0 al editar
Síntoma confirmado: al editar un evento, las filas de cada ítem muestran su monto, pero el **"Total presupuesto"** de arriba sale en 0.

Diagnóstico: el total se calculaba desde `watch("eventoItems")`, que quedaba **desincronizado** con los valores del `useFieldArray` tras el `reset()` que corre en un `useEffect` (al cargar el catálogo). Los inputs mostraban los valores (vía el snapshot del field array) pero `watch()` devolvía 0.

Fix: calcular los totales con **`useWatch({ control, name: "eventoItems" })`** — la forma reactiva recomendada por React Hook Form para valores computados de field arrays.

> ⚠️ **Verificar en vivo antes de mergear:** el diagnóstico está respaldado por el síntoma exacto y el fix es el idiomático, pero el comportamiento runtime de RHF conviene confirmarlo: crear un evento con presupuesto → reabrir en edición → el "Total presupuesto" debe mostrar la suma (no 0). Si siguiera en 0, hay que observar el estado real de RHF corriendo la app.

## Alcance
Frontend-only, ambos. Sin cambios de backend ni de schema.

## Cómo probar
- **Ítem 4:** entrar como PDA a `/eventos` → debe aparecer el `<select>` "Todas las disciplinas" y filtrar.
- **Ítem 7:** crear/editar un evento con ítems presupuestarios → el "Total presupuesto" arriba debe reflejar la suma de los montos.
