### PR TITLE
fix(avales): categoría no persiste al editar, aviso en descarga y documentos en revisión

### DIFF
--- a/app/(app)/avales/[id]/page.tsx
+++ b/app/(app)/avales/[id]/page.tsx
@@ -1058,7 +1058,7 @@ export default function AvalDetailPage() {
                 {regenerating ? "Iniciando..." : "Regenerar PDFs"}
               </button>
             )}
-            {canDownloadAvalCompleto && (
+            {canDownloadAvalCompleto ? (
               <a
                 href={avalCompletoPdfUrl}
                 target="_blank"
@@ -1068,6 +1068,16 @@ export default function AvalDetailPage() {
                 <Download className="w-4 h-4 mr-2" />
                 Descargar aval completo
               </a>
+            ) : (
+              <button
+                type="button"
+                disabled
+                title="El aval completo estará disponible una vez aprobado en todas las etapas."
+                className="btn bg-indigo-500 text-white opacity-50 cursor-not-allowed"
+              >
+                <Download className="w-4 h-4 mr-2" />
+                Descargar aval completo
+              </button>
             )}
           </div>
         </div>

--- a/app/(app)/avales/_components/aval-documentos-section.tsx
+++ b/app/(app)/avales/_components/aval-documentos-section.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Download, FileText, HeartPulse, ClipboardCheck } from "lucide-react";
+import type { Aval, AdjuntoSolicitud } from "@/types/aval";
+
+type Props = {
+  aval: Aval;
+};
+
+function DownloadLink({
+  href,
+  label,
+  icon: Icon,
+}: {
+  href: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer noopener"
+      download
+      className="btn w-full justify-center bg-indigo-500 text-white hover:bg-indigo-600"
+    >
+      <Icon className="w-4 h-4 mr-2" />
+      {label}
+    </a>
+  );
+}
+
+function AdjuntoLink({ adjunto }: { adjunto: AdjuntoSolicitud }) {
+  return (
+    <a
+      href={adjunto.url}
+      target="_blank"
+      rel="noreferrer noopener"
+      download
+      title={`Descargar ${adjunto.nombreOriginal}`}
+      className="btn w-full justify-center bg-indigo-500 text-white hover:bg-indigo-600 truncate"
+    >
+      <Download className="w-4 h-4 mr-2 shrink-0" />
+      <span className="truncate">{adjunto.nombreOriginal}</span>
+    </a>
+  );
+}
+
+export default function AvalDocumentosSection({ aval }: Props) {
+  const hasConvocatoria = Boolean(aval.convocatoriaUrl);
+  const hasCertificado = Boolean(aval.certificadoMedicoUrl);
+  const hasPronostico = Boolean(aval.pronosticoDeportistasUrl);
+  const convocatoriaAdjuntos = aval.convocatoriaAdjuntos ?? [];
+  const pronosticoAdjuntos = aval.pronosticoDeportistasAdjuntos ?? [];
+
+  const hasAny =
+    hasConvocatoria ||
+    hasCertificado ||
+    hasPronostico ||
+    convocatoriaAdjuntos.length > 0 ||
+    pronosticoAdjuntos.length > 0;
+
+  if (!hasAny) return null;
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950/60 p-4 shadow-sm">
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
+        Documentos del aval
+      </p>
+      <div className="space-y-2">
+        {hasConvocatoria && (
+          <DownloadLink
+            href={aval.convocatoriaUrl!}
+            label="Descargar convocatoria"
+            icon={Download}
+          />
+        )}
+        {hasCertificado && (
+          <DownloadLink
+            href={aval.certificadoMedicoUrl!}
+            label="Descargar certificado médico"
+            icon={HeartPulse}
+          />
+        )}
+        {hasPronostico && (
+          <DownloadLink
+            href={aval.pronosticoDeportistasUrl!}
+            label="Descargar pronóstico de deportistas"
+            icon={ClipboardCheck}
+          />
+        )}
+
+        {convocatoriaAdjuntos.length > 0 && (
+          <div className="mt-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+              Convocatorias adicionales
+            </p>
+            <ul className="space-y-2">
+              {convocatoriaAdjuntos.map((adj) => (
+                <li key={adj.id}>
+                  <AdjuntoLink adjunto={adj} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {pronosticoAdjuntos.length > 0 && (
+          <div className="mt-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+              Pronósticos de deportistas adicionales
+            </p>
+            <ul className="space-y-2">
+              {pronosticoAdjuntos.map((adj) => (
+                <li key={adj.id}>
+                  <AdjuntoLink adjunto={adj} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/eventos/_components/evento-form-helpers.ts
+++ b/app/(app)/eventos/_components/evento-form-helpers.ts
@@ -186,6 +186,8 @@ export function buildUpdateEventoPayloadFromForm(
     return null;
   }
 
+  const canonicalCategoriaCodigo = getCanonicalCategory(values.categoriaCodigo);
+
   return {
     codigo: values.codigo.trim(),
     tipoParticipacion,
@@ -195,6 +197,7 @@ export function buildUpdateEventoPayloadFromForm(
     genero: values.genero,
     disciplinaId,
     categoriaId: categoriaId ?? null,
+    ...(canonicalCategoriaCodigo ? { categoriaCodigo: canonicalCategoriaCodigo } : {}),
     mesProgramado: values.mesProgramado,
     provincia: values.provincia.trim(),
     ciudad: values.ciudad.trim(),

--- a/app/(fullscreen)/avales/[id]/certificacion-financiera/page.tsx
+++ b/app/(fullscreen)/avales/[id]/certificacion-financiera/page.tsx
@@ -18,6 +18,7 @@ import { isFinancieroUser } from "@/lib/auth/access";
 import { getApprovalFlowStages } from "@/lib/approval-flow";
 import { getActionConfig, getSectionConfig } from "@/lib/aval-form-config";
 import { useAvalFormConfig } from "@/lib/hooks/use-aval-form-config";
+import AvalDocumentosSection from "@/app/(app)/avales/_components/aval-documentos-section";
 
 type FinancieroDraft = {
   descripcionCertificacion: string;
@@ -458,6 +459,7 @@ export default function CertificacionFinancieraPage() {
       <div className="w-full lg:w-1/2 bg-slate-100 dark:bg-slate-900 overflow-y-auto">
         <div className="p-6 xl:p-8">
           <div className="space-y-6">
+            <AvalDocumentosSection aval={aval} />
             <PreviewCollapsible title="Certificacion PDA">
               <PdaPreview aval={aval} draft={pdaDraft} />
             </PreviewCollapsible>

--- a/app/(fullscreen)/avales/[id]/certificar-compras-publicas/page.tsx
+++ b/app/(fullscreen)/avales/[id]/certificar-compras-publicas/page.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/lib/approval-flow";
 import { getActionConfig, getSectionConfig } from "@/lib/aval-form-config";
 import { useAvalFormConfig } from "@/lib/hooks/use-aval-form-config";
+import AvalDocumentosSection from "@/app/(app)/avales/_components/aval-documentos-section";
 
 const INITIAL_DRAFT: ComprasPublicasDraft = {
   numeroCertificado: "",
@@ -621,6 +622,7 @@ export default function CertificarComprasPublicasPage() {
       <div className="w-full lg:w-1/2 bg-slate-100 dark:bg-slate-900 overflow-y-auto">
         <div className="p-6 xl:p-8">
           <div className="space-y-6">
+            <AvalDocumentosSection aval={aval} />
             <PreviewCollapsible title="Lista deportistas">
               <ListaDeportistasPreview aval={aval} formData={trainerDocsData} />
             </PreviewCollapsible>

--- a/app/(fullscreen)/avales/[id]/certificar-pda/page.tsx
+++ b/app/(fullscreen)/avales/[id]/certificar-pda/page.tsx
@@ -33,6 +33,7 @@ import {
   getNextApprovalStageForAval,
   getPreviousApprovalStagesForAval,
 } from "@/lib/approval-flow";
+import AvalDocumentosSection from "@/app/(app)/avales/_components/aval-documentos-section";
 
 const INITIAL_PDA_DRAFT: PdaDraft = {
   descripcion: "",
@@ -999,6 +1000,7 @@ export default function CertificarAvalPage() {
       <div className="w-full lg:w-1/2 bg-slate-100 dark:bg-slate-900 overflow-y-auto">
         <div className="p-6 xl:p-8">
           <div className="space-y-6">
+            <AvalDocumentosSection aval={aval} />
             <PreviewCollapsible title="Lista deportistas">
               <ListaDeportistasPreview aval={aval} formData={trainerDocsData} />
             </PreviewCollapsible>

--- a/app/(fullscreen)/avales/[id]/revision-control-previo/page.tsx
+++ b/app/(fullscreen)/avales/[id]/revision-control-previo/page.tsx
@@ -43,6 +43,7 @@ import {
   mergeReviewStateFromApi,
   normalizeReviewItems,
 } from "@/app/(app)/avales/_components/revision-metodologo-config";
+import AvalDocumentosSection from "@/app/(app)/avales/_components/aval-documentos-section";
 
 const EMPTY_DOCS_DATA: AvalPreviewFormData = {
   deportistas: [],
@@ -409,6 +410,7 @@ export default function RevisionControlPrevioPage() {
       <div className="w-full lg:w-1/2 bg-slate-100 dark:bg-slate-900 overflow-y-auto">
         <div className="p-6 xl:p-8">
           <div className="space-y-6">
+            <AvalDocumentosSection aval={aval} />
             <PreviewCollapsible title="Lista deportistas" defaultOpen>
               <ListaDeportistasPreview aval={aval} formData={trainerDocsData} />
             </PreviewCollapsible>

--- a/app/(fullscreen)/avales/[id]/revision-dtm/page.tsx
+++ b/app/(fullscreen)/avales/[id]/revision-dtm/page.tsx
@@ -38,6 +38,7 @@ import {
   formatRoles,
   getResponsibleTrainerName,
 } from "@/lib/utils/formatters";
+import AvalDocumentosSection from "@/app/(app)/avales/_components/aval-documentos-section";
 
 const EMPTY_DOCS_DATA: AvalPreviewFormData = {
   deportistas: [],
@@ -600,6 +601,7 @@ export default function RevisionDtmPage() {
       <div className="hidden lg:block lg:w-1/2 bg-slate-100 dark:bg-slate-900 overflow-y-auto">
         <div className="p-6 xl:p-8">
           <div className="space-y-6">
+            <AvalDocumentosSection aval={aval} />
             <PreviewCollapsible title="Solicitud aval">
               <SolicitudAvalPreview aval={aval} formData={trainerDocsData} />
             </PreviewCollapsible>

--- a/app/(fullscreen)/avales/[id]/revision-metodologo/page.tsx
+++ b/app/(fullscreen)/avales/[id]/revision-metodologo/page.tsx
@@ -50,6 +50,7 @@ import {
 import { isMetodologoUser } from "@/lib/auth/access";
 import { getActionConfig, getSectionConfig } from "@/lib/aval-form-config";
 import { useAvalFormConfig } from "@/lib/hooks/use-aval-form-config";
+import AvalDocumentosSection from "@/app/(app)/avales/_components/aval-documentos-section";
 
 const INITIAL_PDA_DRAFT: PdaDraft = {
   descripcion: "",
@@ -791,6 +792,7 @@ export default function RevisionMetodologoPage() {
       <div className="hidden lg:block lg:w-[55%] bg-slate-100 dark:bg-slate-900 border-l border-slate-200 dark:border-slate-800 overflow-y-auto">
         <div className="p-6 xl:p-8">
           <div className="space-y-6">
+            <AvalDocumentosSection aval={aval} />
             <PreviewCollapsible title="Solicitud aval">
               <SolicitudAvalPreview aval={aval} formData={trainerDocsData} />
             </PreviewCollapsible>

--- a/lib/api/eventos.ts
+++ b/lib/api/eventos.ts
@@ -160,6 +160,7 @@ export type UpdateEventoPayload = {
   genero?: "MASCULINO" | "FEMENINO" | "MASCULINO_FEMENINO";
   disciplinaId?: number;
   categoriaId?: number | null;
+  categoriaCodigo?: string;
   mesProgramado?: number;
   provincia?: string;
   ciudad?: string;


### PR DESCRIPTION
## Resumen

Este PR agrupa tres correcciones del sistema de avales.

## Item 1 — Categoría no se guardaba al editar un evento

**Causa raíz:** Al editar la categoría de un evento, `resolveCategoriaCatalogItem` puede no encontrar la coincidencia exacta entre el valor del formulario (canónico, e.g. `ESCUELAS_INICIACION`) y el `codigo` devuelto por la API del catálogo (e.g. `ESCUELAS_DE_INICIACION`). En ese caso `categoriaId` quedaba en `null` y se enviaba al backend como `categoriaId: null`, sobreescribiendo la categoría guardada. El backend tiene un fallback que resuelve por `categoriaCodigo`, pero ese campo nunca se incluía en el payload de actualización.

**Fix:** Se agrega `categoriaCodigo` (valor canónico, normalizado por `getCanonicalCategory`) al tipo `UpdateEventoPayload` y a la función `buildUpdateEventoPayloadFromForm`. Así, aunque `categoriaId` llegue como `null`, el backend puede resolverlo por código. Se mantiene el envío de `categoriaId` cuando la resolución frontend sí funciona — ambos campos se envían juntos para máxima robustez.

**Mecanismo probado:** El controlador `events.controller.ts` (líneas 248–255) ya tenía el fallback: si `categoriaCodigo && !categoriaId`, consulta `prisma.categoria.findFirst({ where: { codigo } })` y asigna el ID antes de persistir. Con este cambio, ese fallback ya tiene el dato que necesita.

## Item 12 — Aviso al intentar descargar el aval completo

Cuando `canDownloadAvalCompleto` es `false`, el botón "Descargar aval completo" ahora se muestra deshabilitado con un `title` explicativo: *"El aval completo estará disponible una vez aprobado en todas las etapas."* Antes simplemente se ocultaba, dejando al usuario sin información.

## Item 14 — Documentos visibles en todos los pasos de revisión

Se extrae el componente `AvalDocumentosSection` (solo descarga, sin opciones de subida) y se monta en la parte superior del panel derecho de las seis páginas de revisión en pantalla completa:
- `certificar-pda`
- `certificar-compras-publicas`
- `revision-metodologo`
- `revision-dtm`
- `revision-control-previo`
- `certificacion-financiera`

El componente se oculta automáticamente si no hay documentos disponibles, y filtra individualmente los links con URL nula.

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `lib/api/eventos.ts` | Agrega `categoriaCodigo?` a `UpdateEventoPayload` |
| `app/(app)/eventos/_components/evento-form-helpers.ts` | Incluye `categoriaCodigo` en `buildUpdateEventoPayloadFromForm` |
| `app/(app)/avales/[id]/page.tsx` | Botón deshabilitado con tooltip para "Descargar aval completo" |
| `app/(app)/avales/_components/aval-documentos-section.tsx` | Nuevo componente read-only de documentos del aval |
| `app/(fullscreen)/avales/[id]/certificar-pda/page.tsx` | Monta `AvalDocumentosSection` |
| `app/(fullscreen)/avales/[id]/certificar-compras-publicas/page.tsx` | Monta `AvalDocumentosSection` |
| `app/(fullscreen)/avales/[id]/revision-metodologo/page.tsx` | Monta `AvalDocumentosSection` |
| `app/(fullscreen)/avales/[id]/revision-dtm/page.tsx` | Monta `AvalDocumentosSection` |
| `app/(fullscreen)/avales/[id]/revision-control-previo/page.tsx` | Monta `AvalDocumentosSection` |
| `app/(fullscreen)/avales/[id]/certificacion-financiera/page.tsx` | Monta `AvalDocumentosSection` |

## Build

`npm run build` pasa sin errores nuevos.