### PR TITLE
feat(reformas-multi): N→M budget transfer UI (frontend)

### DIFF
--- a/app/(app)/reformas-multi/[id]/page.tsx
+++ b/app/(app)/reformas-multi/[id]/page.tsx
@@ -1,0 +1,581 @@
+"use client";
+
+import { Fragment, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, Calendar, ClipboardEdit } from "lucide-react";
+import { Dialog, Transition } from "@headlessui/react";
+
+import { useAuth } from "@/app/providers/auth-provider";
+import AlertBanner from "@/components/ui/alert-banner";
+import {
+  getReformaMulti,
+  aprobarReformaMulti,
+  rechazarReformaMulti,
+  ESTADO_REFORMA_MULTI_LABELS,
+  FUENTE_REFORMA_LABELS,
+  MES_NOMBRES,
+  getErrorMessage,
+} from "@/lib/api/reforms-multi";
+import { canReviewReforms } from "@/lib/auth/access";
+import { formatCurrencyFromString, formatDateTime } from "@/lib/utils/formatters";
+import type { CambiosSnapshot } from "@/types/reforma-multi";
+
+const STATUS_STYLES: Record<string, string> = {
+  PENDIENTE:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200",
+  APROBADA:
+    "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200",
+  RECHAZADA:
+    "bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200",
+};
+
+function getStatusClasses(status?: string | null) {
+  if (!status) return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
+  return (
+    STATUS_STYLES[status.toUpperCase()] ??
+    "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+  );
+}
+
+export default function ReformaMultiDetailPage() {
+  const params = useParams();
+  const id = Number(params.id);
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [observacion, setObservacion] = useState("");
+  const [observacionError, setObservacionError] = useState<string | null>(null);
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const canReview = canReviewReforms(user);
+
+  const {
+    data,
+    isLoading,
+    error: fetchError,
+  } = useQuery({
+    queryKey: ["reforma-multi", id],
+    queryFn: () => getReformaMulti(id),
+    enabled: !Number.isNaN(id) && id > 0,
+  });
+
+  const reform = data?.data;
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["reforma-multi", id] });
+
+  const aprobarMutation = useMutation({
+    mutationFn: () => aprobarReformaMulti(id),
+    onSuccess: async () => {
+      setActionSuccess("Reforma aprobada correctamente.");
+      setActionError(null);
+      await invalidate();
+    },
+    onError: (err) => {
+      setActionError(getErrorMessage(err));
+      setActionSuccess(null);
+    },
+  });
+
+  const rechazarMutation = useMutation({
+    mutationFn: (obs: string) => rechazarReformaMulti(id, obs),
+    onSuccess: async () => {
+      setActionSuccess("Reforma rechazada correctamente.");
+      setActionError(null);
+      setRejectOpen(false);
+      setObservacion("");
+      await invalidate();
+    },
+    onError: (err) => {
+      setActionError(getErrorMessage(err));
+      setActionSuccess(null);
+    },
+  });
+
+  const handleAprobar = () => {
+    if (!reform || reform.estado !== "PENDIENTE") return;
+    setActionError(null);
+    setActionSuccess(null);
+    aprobarMutation.mutate();
+  };
+
+  const handleOpenReject = () => {
+    setObservacionError(null);
+    setRejectOpen(true);
+  };
+
+  const handleConfirmReject = () => {
+    const trimmed = observacion.trim();
+    if (!trimmed) {
+      setObservacionError("Debes indicar una observación para el rechazo.");
+      return;
+    }
+    if (trimmed.length > 600) {
+      setObservacionError("La observación no puede superar los 600 caracteres.");
+      return;
+    }
+    rechazarMutation.mutate(trimmed);
+  };
+
+  const actionsLoading = aprobarMutation.isPending || rechazarMutation.isPending;
+
+  if (!id || Number.isNaN(id)) {
+    return (
+      <div className="px-4 py-8 sm:px-6 lg:px-8">
+        <AlertBanner variant="error" message="ID de reforma inválido." />
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-5xl space-y-4">
+          <div className="h-8 w-56 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="h-40 animate-pulse rounded-xl bg-gray-200 dark:bg-gray-700" />
+          <div className="h-64 animate-pulse rounded-xl bg-gray-200 dark:bg-gray-700" />
+        </div>
+      </div>
+    );
+  }
+
+  if (fetchError || !reform) {
+    return (
+      <div className="px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-4xl space-y-4">
+          <AlertBanner
+            variant="error"
+            message={
+              fetchError instanceof Error
+                ? fetchError.message
+                : "No se encontró la reforma."
+            }
+          />
+          <Link
+            href="/reformas-multi"
+            className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Volver a reformas multi-evento
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const cambios = reform.cambios as CambiosSnapshot | null | undefined;
+
+  return (
+    <div className="px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-5xl space-y-6">
+        {actionSuccess ? (
+          <AlertBanner
+            variant="success"
+            message={actionSuccess}
+            onClose={() => setActionSuccess(null)}
+          />
+        ) : null}
+        {actionError ? (
+          <AlertBanner
+            variant="error"
+            message={actionError}
+            onClose={() => setActionError(null)}
+          />
+        ) : null}
+
+        {/* Back + header */}
+        <div>
+          <Link
+            href="/reformas-multi"
+            className="inline-flex items-center gap-2 text-sm text-gray-500 transition hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Volver a reformas multi-evento
+          </Link>
+
+          <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-sm font-medium uppercase tracking-[0.18em] text-amber-700 dark:text-amber-300">
+                Reforma Multi-Evento
+              </p>
+              <h1 className="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
+                Reforma #{reform.id}
+              </h1>
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 line-clamp-2">
+                {reform.motivo}
+              </p>
+            </div>
+            <div className="flex flex-col items-start gap-2 sm:items-end">
+              <span
+                className={`inline-flex rounded-full px-3 py-1 text-sm font-medium ${getStatusClasses(reform.estado)}`}
+              >
+                {ESTADO_REFORMA_MULTI_LABELS[reform.estado] ?? reform.estado}
+              </span>
+              <span className="inline-flex rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+                {FUENTE_REFORMA_LABELS[reform.fuente] ?? reform.fuente}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Metadata */}
+        <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div className="mb-4 flex items-center gap-2">
+            <ClipboardEdit className="h-5 w-5 text-gray-400" />
+            <h2 className="font-semibold text-gray-900 dark:text-gray-100">Solicitud</h2>
+          </div>
+          <dl className="grid gap-4 sm:grid-cols-2 text-sm">
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">Motivo</dt>
+              <dd className="mt-1 text-gray-900 dark:text-gray-100">{reform.motivo}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">Mes de ejecución</dt>
+              <dd className="mt-1 inline-flex items-center gap-2 text-gray-900 dark:text-gray-100">
+                <Calendar className="h-4 w-4 text-gray-400" />
+                {MES_NOMBRES[reform.mesEjecucion] ?? `Mes ${reform.mesEjecucion}`}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">Solicitante</dt>
+              <dd className="mt-1 text-gray-900 dark:text-gray-100">
+                {reform.solicitante.nombre} {reform.solicitante.apellido}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">Fecha de solicitud</dt>
+              <dd className="mt-1 text-gray-900 dark:text-gray-100">
+                {formatDateTime(reform.createdAt)}
+              </dd>
+            </div>
+            {reform.aprobador ? (
+              <>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Revisado por</dt>
+                  <dd className="mt-1 text-gray-900 dark:text-gray-100">
+                    {reform.aprobador.nombre} {reform.aprobador.apellido}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Fecha de revisión</dt>
+                  <dd className="mt-1 text-gray-900 dark:text-gray-100">
+                    {reform.reviewedAt ? formatDateTime(reform.reviewedAt) : "-"}
+                  </dd>
+                </div>
+              </>
+            ) : null}
+            {reform.observacion ? (
+              <div className="sm:col-span-2">
+                <dt className="text-gray-500 dark:text-gray-400">Observación</dt>
+                <dd className="mt-1 text-gray-900 dark:text-gray-100">{reform.observacion}</dd>
+              </div>
+            ) : null}
+          </dl>
+        </section>
+
+        {/* Origenes / Destinos side-by-side */}
+        <div className="grid gap-4 lg:grid-cols-2">
+          {/* Origenes */}
+          <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <h2 className="mb-3 font-semibold text-gray-900 dark:text-gray-100">
+              Eventos de origen ({reform.origenes.length})
+            </h2>
+            {reform.origenes.length === 0 ? (
+              <p className="text-sm text-gray-400 dark:text-gray-500">Sin orígenes.</p>
+            ) : (
+              <ul className="space-y-3">
+                {reform.origenes.map((origen) => {
+                  const eventoId = origen.eventoId;
+                  const cambioOrigen = cambios?.origenes.find(
+                    (c) => c.eventoId === eventoId,
+                  );
+                  return (
+                    <li
+                      key={origen.id}
+                      className="rounded-lg border border-rose-100 bg-rose-50/50 p-3 dark:border-rose-900/30 dark:bg-rose-900/10"
+                    >
+                      <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                        {origen.evento.nombre}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {origen.evento.codigo}
+                        {origen.evento.disciplina
+                          ? ` · ${origen.evento.disciplina.nombre}`
+                          : ""}
+                      </p>
+                      <dl className="mt-2 grid grid-cols-2 gap-1 text-xs">
+                        <div>
+                          <dt className="text-gray-500 dark:text-gray-400">Monto cortado</dt>
+                          <dd className="font-medium text-rose-700 dark:text-rose-400">
+                            -{formatCurrencyFromString(origen.montoCortado)}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className="text-gray-500 dark:text-gray-400">Total antes</dt>
+                          <dd className="font-medium text-gray-900 dark:text-gray-100">
+                            {formatCurrencyFromString(origen.totalEventoAntes)}
+                          </dd>
+                        </div>
+                        {origen.totalEventoDespues != null ? (
+                          <div className="col-span-2">
+                            <dt className="text-gray-500 dark:text-gray-400">Total después</dt>
+                            <dd className="font-medium text-gray-900 dark:text-gray-100">
+                              {formatCurrencyFromString(origen.totalEventoDespues)}
+                            </dd>
+                          </div>
+                        ) : null}
+                      </dl>
+
+                      {/* Before/after items from cambios */}
+                      {reform.estado === "APROBADA" && cambioOrigen && (
+                        <details className="mt-2">
+                          <summary className="cursor-pointer text-xs text-indigo-600 dark:text-indigo-400">
+                            Ver cambios por ítem
+                          </summary>
+                          <div className="mt-2 grid grid-cols-2 gap-2">
+                            <div>
+                              <p className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                Antes
+                              </p>
+                              {cambioOrigen.before.map((b) => (
+                                <p key={b.itemId} className="text-xs text-gray-700 dark:text-gray-300">
+                                  Item #{b.itemId}: {formatCurrencyFromString(b.presupuesto)}
+                                </p>
+                              ))}
+                            </div>
+                            <div>
+                              <p className="text-[10px] font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-400">
+                                Después
+                              </p>
+                              {cambioOrigen.after.map((a) => (
+                                <p key={a.itemId} className="text-xs text-gray-700 dark:text-gray-300">
+                                  Item #{a.itemId}: {formatCurrencyFromString(a.presupuesto)}
+                                </p>
+                              ))}
+                            </div>
+                          </div>
+                        </details>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
+
+          {/* Destinos */}
+          <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <h2 className="mb-3 font-semibold text-gray-900 dark:text-gray-100">
+              Eventos de destino ({reform.destinos.length})
+            </h2>
+            {reform.destinos.length === 0 ? (
+              <p className="text-sm text-gray-400 dark:text-gray-500">Sin destinos.</p>
+            ) : (
+              <ul className="space-y-3">
+                {reform.destinos.map((destino) => {
+                  const eventoId = destino.eventoId;
+                  const cambioDestino = cambios?.destinos.find(
+                    (c) => c.eventoId === eventoId,
+                  );
+                  return (
+                    <li
+                      key={destino.id}
+                      className="rounded-lg border border-emerald-100 bg-emerald-50/50 p-3 dark:border-emerald-900/30 dark:bg-emerald-900/10"
+                    >
+                      <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                        {destino.evento.nombre}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {destino.evento.codigo}
+                        {destino.evento.disciplina
+                          ? ` · ${destino.evento.disciplina.nombre}`
+                          : ""}
+                      </p>
+                      <dl className="mt-2 grid grid-cols-2 gap-1 text-xs">
+                        <div>
+                          <dt className="text-gray-500 dark:text-gray-400">Monto asignado</dt>
+                          <dd className="font-medium text-emerald-700 dark:text-emerald-400">
+                            +{formatCurrencyFromString(destino.montoAsignado)}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className="text-gray-500 dark:text-gray-400">Total antes</dt>
+                          <dd className="font-medium text-gray-900 dark:text-gray-100">
+                            {formatCurrencyFromString(destino.totalEventoAntes)}
+                          </dd>
+                        </div>
+                        {destino.totalEventoDespues != null ? (
+                          <div className="col-span-2">
+                            <dt className="text-gray-500 dark:text-gray-400">Total después</dt>
+                            <dd className="font-medium text-gray-900 dark:text-gray-100">
+                              {formatCurrencyFromString(destino.totalEventoDespues)}
+                            </dd>
+                          </div>
+                        ) : null}
+                      </dl>
+
+                      {/* Before/after items from cambios */}
+                      {reform.estado === "APROBADA" && cambioDestino && (
+                        <details className="mt-2">
+                          <summary className="cursor-pointer text-xs text-indigo-600 dark:text-indigo-400">
+                            Ver cambios por ítem
+                          </summary>
+                          <div className="mt-2 grid grid-cols-2 gap-2">
+                            <div>
+                              <p className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                Antes
+                              </p>
+                              {cambioDestino.before.map((b) => (
+                                <p key={b.itemId} className="text-xs text-gray-700 dark:text-gray-300">
+                                  Item #{b.itemId}: {formatCurrencyFromString(b.presupuesto)}
+                                </p>
+                              ))}
+                            </div>
+                            <div>
+                              <p className="text-[10px] font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-400">
+                                Después
+                              </p>
+                              {cambioDestino.after.map((a) => (
+                                <p key={a.itemId} className="text-xs text-gray-700 dark:text-gray-300">
+                                  Item #{a.itemId}: {formatCurrencyFromString(a.presupuesto)}
+                                </p>
+                              ))}
+                            </div>
+                          </div>
+                        </details>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
+        </div>
+
+        {/* Approve / Reject actions */}
+        {canReview && reform.estado === "PENDIENTE" ? (
+          <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              Revisión de reforma multi-evento
+            </h2>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Al aprobar, los presupuestos de todos los eventos serán modificados
+              de forma atómica.
+            </p>
+            <div className="mt-4 flex flex-wrap justify-end gap-3">
+              <button
+                type="button"
+                disabled={actionsLoading}
+                onClick={handleOpenReject}
+                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-rose-600 to-rose-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg hover:from-rose-500 hover:to-rose-400 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500"
+              >
+                Rechazar
+              </button>
+              <button
+                type="button"
+                disabled={actionsLoading}
+                onClick={handleAprobar}
+                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-emerald-600 to-emerald-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg hover:from-emerald-500 hover:to-emerald-400 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500"
+              >
+                {aprobarMutation.isPending ? "Aprobando..." : "Aprobar"}
+              </button>
+            </div>
+          </section>
+        ) : null}
+      </div>
+
+      {/* Reject modal */}
+      <Transition.Root show={rejectOpen} as={Fragment}>
+        <Dialog
+          as="div"
+          className="relative z-50"
+          role="dialog"
+          onClose={() => {
+            if (!rechazarMutation.isPending) setRejectOpen(false);
+          }}
+        >
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-200"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-150"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-gray-900/40 backdrop-blur-sm" />
+          </Transition.Child>
+
+          <div className="fixed inset-0 z-50 overflow-y-auto">
+            <div className="flex min-h-full items-center justify-center p-4 text-center">
+              <Transition.Child
+                as={Fragment}
+                enter="ease-out duration-200"
+                enterFrom="opacity-0 translate-y-2 scale-95"
+                enterTo="opacity-100 translate-y-0 scale-100"
+                leave="ease-in duration-150"
+                leaveFrom="opacity-100 translate-y-0 scale-100"
+                leaveTo="opacity-0 translate-y-2 scale-95"
+              >
+                <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-xl border border-gray-200 bg-white text-left align-middle shadow-xl transition-all dark:border-gray-700/60 dark:bg-gray-800">
+                  <div className="space-y-3 px-6 py-5">
+                    <Dialog.Title className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                      Rechazar reforma multi-evento
+                    </Dialog.Title>
+                    <Dialog.Description className="text-sm text-gray-600 dark:text-gray-300">
+                      Indica el motivo del rechazo. Será visible para el solicitante.
+                    </Dialog.Description>
+                    <div className="space-y-2">
+                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        Observación (obligatoria)
+                      </label>
+                      <textarea
+                        value={observacion}
+                        onChange={(e) => {
+                          setObservacion(e.target.value);
+                          if (observacionError) setObservacionError(null);
+                        }}
+                        maxLength={600}
+                        rows={3}
+                        className="form-textarea w-full border border-gray-300 bg-white text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                        placeholder="Describe el motivo del rechazo..."
+                      />
+                      <p className="text-right text-xs text-gray-400">
+                        {observacion.length}/600
+                      </p>
+                      {observacionError ? (
+                        <p className="text-sm text-rose-500">{observacionError}</p>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="flex justify-end gap-2 border-t border-gray-200 bg-gray-50/60 px-6 py-4 dark:border-gray-700/60 dark:bg-gray-900/30">
+                    <button
+                      type="button"
+                      className="btn border-gray-200 text-gray-700 hover:border-gray-300 dark:border-gray-700/60 dark:text-gray-200 dark:hover:border-gray-600"
+                      onClick={() => setRejectOpen(false)}
+                      disabled={rechazarMutation.isPending}
+                    >
+                      Cancelar
+                    </button>
+                    <button
+                      type="button"
+                      className="btn bg-rose-600 text-white hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-60"
+                      onClick={handleConfirmReject}
+                      disabled={rechazarMutation.isPending}
+                    >
+                      {rechazarMutation.isPending ? "Rechazando..." : "Rechazar"}
+                    </button>
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition.Root>
+    </div>
+  );
+}

--- a/app/(app)/reformas-multi/_components/balance-bar.tsx
+++ b/app/(app)/reformas-multi/_components/balance-bar.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Decimal from "decimal.js";
+import { formatCurrency } from "@/lib/utils/formatters";
+
+type Props = {
+  totalCortado: number;
+  totalAsignado: number;
+};
+
+export default function BalanceBar({ totalCortado, totalAsignado }: Props) {
+  const cortado = new Decimal(totalCortado || 0);
+  const asignado = new Decimal(totalAsignado || 0);
+  const balanced = cortado.equals(asignado);
+  const diff = cortado.minus(asignado).toNumber();
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/40">
+      <div className="grid grid-cols-3 gap-4 text-center">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Total cortado
+          </p>
+          <p className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {formatCurrency(cortado.toNumber())}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Total a distribuir
+          </p>
+          <p className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {formatCurrency(asignado.toNumber())}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Balance
+          </p>
+          <p
+            className={`mt-1 text-lg font-semibold ${
+              balanced
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-rose-600 dark:text-rose-400"
+            }`}
+          >
+            {balanced ? "✓ Balanceado" : `✗ ${diff > 0 ? "+" : ""}${formatCurrency(diff)}`}
+          </p>
+        </div>
+      </div>
+      {!balanced && (
+        <p className="mt-3 text-center text-xs text-rose-500 dark:text-rose-400">
+          La suma de montos de origen debe ser igual a la de destino para poder
+          enviar la solicitud.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Returns true when totalCortado and totalAsignado are equal to cent precision. */
+export function isBalanced(
+  totalCortado: number,
+  totalAsignado: number,
+): boolean {
+  const cortado = new Decimal(totalCortado || 0);
+  const asignado = new Decimal(totalAsignado || 0);
+  return cortado.equals(asignado);
+}

--- a/app/(app)/reformas-multi/_components/multi-event-selector.tsx
+++ b/app/(app)/reformas-multi/_components/multi-event-selector.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { X, Search } from "lucide-react";
+import type { Evento } from "@/types/evento";
+import { listEventos } from "@/lib/api/eventos";
+import type { FuentePresupuestoReforma } from "@/types/reforma-multi";
+import { formatCurrencyFromString } from "@/lib/utils/formatters";
+
+export type SelectedEvento = {
+  eventoId: number;
+  nombre: string;
+  codigo: string;
+  monto: number;
+  totalDisponible: number;
+};
+
+type Props = {
+  label: string;
+  fuente: FuentePresupuestoReforma | "";
+  selected: SelectedEvento[];
+  onChange: (updated: SelectedEvento[]) => void;
+  excludeIds?: number[];
+};
+
+export default function MultiEventSelector({
+  label,
+  fuente,
+  selected,
+  onChange,
+  excludeIds = [],
+}: Props) {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [results, setResults] = useState<Evento[]>([]);
+  const [loadingSearch, setLoadingSearch] = useState(false);
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const montoErrors = useRef<Record<number, string>>({});
+
+  // Debounce search input
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 350);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  // Fetch events when search or fuente changes
+  useEffect(() => {
+    if (!fuente) {
+      setResults([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchEvents() {
+      setLoadingSearch(true);
+      try {
+        const res = await listEventos({
+          search: debouncedSearch || undefined,
+          limit: 20,
+        });
+        if (!cancelled) {
+          const eventos = (res.data ?? []).filter((e) => {
+            if (excludeIds.includes(e.id)) return false;
+            if (selected.some((s) => s.eventoId === e.id)) return false;
+            // Filter by fuente: event must have items with matching fuente
+            if (fuente) {
+              const hasMatchingFuente = e.eventoItems?.some(
+                (item) => item.fuente === fuente,
+              );
+              if (e.eventoItems && e.eventoItems.length > 0 && !hasMatchingFuente) {
+                return false;
+              }
+            }
+            return true;
+          });
+          setResults(eventos);
+        }
+      } catch {
+        if (!cancelled) setResults([]);
+      } finally {
+        if (!cancelled) setLoadingSearch(false);
+      }
+    }
+
+    void fetchEvents();
+    return () => {
+      cancelled = true;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch, fuente]);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  function getTotalDisponible(evento: Evento): number {
+    if (!evento.eventoItems) return 0;
+    return evento.eventoItems
+      .filter((item) => !fuente || item.fuente === fuente)
+      .reduce((sum, item) => {
+        const presupuesto = parseFloat(item.presupuesto) || 0;
+        const comprometido = parseFloat(item.montoComprometido) || 0;
+        const ejecutado = parseFloat(item.montoEjecutado) || 0;
+        return sum + presupuesto - comprometido - ejecutado;
+      }, 0);
+  }
+
+  function handleSelect(evento: Evento) {
+    const totalDisponible = getTotalDisponible(evento);
+    onChange([
+      ...selected,
+      {
+        eventoId: evento.id,
+        nombre: evento.nombre,
+        codigo: evento.codigo,
+        monto: 0,
+        totalDisponible,
+      },
+    ]);
+    setSearch("");
+    setOpen(false);
+  }
+
+  function handleRemove(eventoId: number) {
+    onChange(selected.filter((s) => s.eventoId !== eventoId));
+    const next = { ...montoErrors.current };
+    delete next[eventoId];
+    montoErrors.current = next;
+  }
+
+  function handleMontoChange(eventoId: number, rawValue: string) {
+    const parsed = parseFloat(rawValue);
+    const monto = Number.isNaN(parsed) ? 0 : parsed;
+
+    const item = selected.find((s) => s.eventoId === eventoId);
+    if (item && monto > item.totalDisponible) {
+      montoErrors.current = {
+        ...montoErrors.current,
+        [eventoId]: `Supera el disponible (${formatCurrencyFromString(String(item.totalDisponible))})`,
+      };
+    } else {
+      const next = { ...montoErrors.current };
+      delete next[eventoId];
+      montoErrors.current = next;
+    }
+
+    onChange(
+      selected.map((s) =>
+        s.eventoId === eventoId ? { ...s, monto } : s,
+      ),
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-semibold text-gray-700 dark:text-gray-300">{label}</p>
+
+      {/* Search dropdown */}
+      <div className="relative" ref={dropdownRef}>
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+          <input
+            type="text"
+            className="form-input w-full pl-9 pr-4"
+            placeholder={fuente ? "Buscar evento por nombre o código..." : "Selecciona una fuente primero"}
+            value={search}
+            disabled={!fuente}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => setOpen(true)}
+          />
+        </div>
+
+        {open && fuente && (
+          <div className="absolute z-20 mt-1 w-full rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800">
+            {loadingSearch ? (
+              <div className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+                Buscando...
+              </div>
+            ) : results.length === 0 ? (
+              <div className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+                No se encontraron eventos disponibles.
+              </div>
+            ) : (
+              <ul className="max-h-48 overflow-y-auto divide-y divide-gray-100 dark:divide-gray-700">
+                {results.map((evento) => (
+                  <li key={evento.id}>
+                    <button
+                      type="button"
+                      className="w-full px-4 py-2.5 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                      onClick={() => handleSelect(evento)}
+                    >
+                      <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        {evento.nombre}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {evento.codigo}
+                        {evento.disciplina ? ` · ${evento.disciplina.nombre}` : ""}
+                      </p>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Selected chips with monto inputs */}
+      {selected.length > 0 && (
+        <ul className="space-y-2">
+          {selected.map((item) => {
+            const err = montoErrors.current[item.eventoId];
+            return (
+              <li
+                key={item.eventoId}
+                className="flex flex-col gap-1.5 rounded-xl border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
+                      {item.nombre}
+                    </p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      {item.codigo}
+                      {item.totalDisponible > 0
+                        ? ` · Disponible: ${formatCurrencyFromString(String(item.totalDisponible))}`
+                        : ""}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(item.eventoId)}
+                    className="flex-shrink-0 rounded-full p-1 text-gray-400 hover:bg-gray-200 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+                    aria-label={`Quitar ${item.nombre}`}
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs text-gray-500 dark:text-gray-400">
+                    Monto (USD)
+                  </label>
+                  <input
+                    type="number"
+                    min="0.01"
+                    step="0.01"
+                    value={item.monto === 0 ? "" : item.monto}
+                    onChange={(e) =>
+                      handleMontoChange(item.eventoId, e.target.value)
+                    }
+                    className={`form-input w-full text-sm ${err ? "border-rose-400 dark:border-rose-500" : ""}`}
+                    placeholder="0.00"
+                  />
+                  {err ? (
+                    <p className="mt-1 text-xs text-rose-500">{err}</p>
+                  ) : null}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {selected.length === 0 && (
+        <p className="text-xs text-gray-400 dark:text-gray-500">
+          Ningún evento seleccionado.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/reformas-multi/nueva/page.tsx
+++ b/app/(app)/reformas-multi/nueva/page.tsx
@@ -1,0 +1,436 @@
+"use client";
+
+import { Fragment, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Dialog, Transition } from "@headlessui/react";
+import { useMutation } from "@tanstack/react-query";
+
+import { useAuth } from "@/app/providers/auth-provider";
+import AlertBanner from "@/components/ui/alert-banner";
+import {
+  createReformaMulti,
+  MES_OPCIONES,
+  getErrorMessage,
+} from "@/lib/api/reforms-multi";
+import { canCreateReforma, getNormalizedRoles } from "@/lib/auth/access";
+import { formatCurrency } from "@/lib/utils/formatters";
+import MultiEventSelector, {
+  type SelectedEvento,
+} from "../_components/multi-event-selector";
+import BalanceBar, { isBalanced } from "../_components/balance-bar";
+import type { FuentePresupuestoReforma } from "@/types/reforma-multi";
+
+type Step = "form" | "confirm";
+
+export default function NuevaReformaMultiPage() {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  const roles = getNormalizedRoles(user);
+  const isPda = roles.includes("PDA");
+  const canCreate = canCreateReforma(user) || isPda;
+
+  const [step, setStep] = useState<Step>("form");
+
+  // Form state
+  const [motivo, setMotivo] = useState("");
+  const [mesEjecucion, setMesEjecucion] = useState<number | "">("");
+  const [fuente, setFuente] = useState<FuentePresupuestoReforma | "">("");
+  const [origenes, setOrigenes] = useState<SelectedEvento[]>([]);
+  const [destinos, setDestinos] = useState<SelectedEvento[]>([]);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const totalCortado = useMemo(
+    () => origenes.reduce((sum, e) => sum + e.monto, 0),
+    [origenes],
+  );
+
+  const totalAsignado = useMemo(
+    () => destinos.reduce((sum, e) => sum + e.monto, 0),
+    [destinos],
+  );
+
+  const balanced = isBalanced(totalCortado, totalAsignado);
+
+  const hasMontoErrors = useMemo(
+    () =>
+      origenes.some((e) => e.monto <= 0 || e.monto > e.totalDisponible) ||
+      destinos.some((e) => e.monto <= 0),
+    [origenes, destinos],
+  );
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createReformaMulti({
+        motivo: motivo.trim(),
+        mesEjecucion: Number(mesEjecucion),
+        fuente: fuente as FuentePresupuestoReforma,
+        eventosOrigen: origenes.map((e) => ({
+          eventoId: e.eventoId,
+          monto: e.monto,
+        })),
+        eventosDestino: destinos.map((e) => ({
+          eventoId: e.eventoId,
+          monto: e.monto,
+        })),
+      }),
+    onSuccess: (res) => {
+      const id = res.data?.id;
+      if (id) {
+        router.push(`/reformas-multi/${id}`);
+      } else {
+        router.push("/reformas-multi");
+      }
+    },
+    onError: (err) => {
+      setFormError(getErrorMessage(err));
+      setStep("form");
+    },
+  });
+
+  if (!canCreate) {
+    return (
+      <div className="px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <AlertBanner
+            variant="error"
+            message="No tienes permiso para crear reformas multi-evento."
+          />
+          <Link
+            href="/reformas-multi"
+            className="mt-4 inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Volver a reformas
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  function validateForm(): string | null {
+    if (!motivo.trim()) return "El motivo es obligatorio.";
+    if (motivo.trim().length > 600)
+      return "El motivo no puede superar los 600 caracteres.";
+    if (!mesEjecucion) return "Selecciona el mes de ejecución.";
+    if (!fuente) return "Selecciona la fuente presupuestaria.";
+    if (origenes.length === 0)
+      return "Debes seleccionar al menos un evento de origen.";
+    if (destinos.length === 0)
+      return "Debes seleccionar al menos un evento de destino.";
+    if (origenes.some((e) => e.monto <= 0))
+      return "Todos los montos de origen deben ser mayores a 0.";
+    if (destinos.some((e) => e.monto <= 0))
+      return "Todos los montos de destino deben ser mayores a 0.";
+    if (!balanced)
+      return "La suma de montos de origen debe ser igual a la de destino.";
+    // origin ≠ destination overlap check (frontend guard)
+    const origenIds = new Set(origenes.map((e) => e.eventoId));
+    const overlap = destinos.some((e) => origenIds.has(e.eventoId));
+    if (overlap)
+      return "Un mismo evento no puede ser origen y destino a la vez.";
+    return null;
+  }
+
+  function handleContinue() {
+    const err = validateForm();
+    if (err) {
+      setFormError(err);
+      return;
+    }
+    setFormError(null);
+    setStep("confirm");
+  }
+
+  function handleConfirmSubmit() {
+    mutation.mutate();
+  }
+
+  const origenExcludeIds = destinos.map((e) => e.eventoId);
+  const destinoExcludeIds = origenes.map((e) => e.eventoId);
+
+  return (
+    <div className="px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div>
+          <Link
+            href="/reformas-multi"
+            className="inline-flex items-center gap-2 text-sm text-gray-500 transition hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Volver a reformas multi-evento
+          </Link>
+          <h1 className="mt-4 text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Nueva reforma multi-evento
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Solicita una transferencia presupuestaria entre múltiples eventos.
+          </p>
+        </div>
+
+        {formError ? (
+          <AlertBanner
+            variant="error"
+            message={formError}
+            onClose={() => setFormError(null)}
+          />
+        ) : null}
+
+        <div className="space-y-5 rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          {/* Motivo */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Motivo <span className="text-rose-500">*</span>
+            </label>
+            <textarea
+              value={motivo}
+              onChange={(e) => setMotivo(e.target.value)}
+              rows={3}
+              maxLength={600}
+              className="form-textarea w-full border border-gray-300 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              placeholder="Describe el motivo de la reforma..."
+            />
+            <p className="mt-1 text-right text-xs text-gray-400">
+              {motivo.length}/600
+            </p>
+          </div>
+
+          {/* Mes + Fuente */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Mes de ejecución <span className="text-rose-500">*</span>
+              </label>
+              <select
+                value={mesEjecucion}
+                onChange={(e) =>
+                  setMesEjecucion(e.target.value ? Number(e.target.value) : "")
+                }
+                className="form-select w-full border border-gray-300 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              >
+                <option value="">Selecciona un mes</option>
+                {MES_OPCIONES.map((mes) => (
+                  <option key={mes.value} value={mes.value}>
+                    {mes.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Fuente presupuestaria <span className="text-rose-500">*</span>
+              </label>
+              <select
+                value={fuente}
+                onChange={(e) => {
+                  setFuente((e.target.value as FuentePresupuestoReforma) || "");
+                  // Reset selections when fuente changes
+                  setOrigenes([]);
+                  setDestinos([]);
+                }}
+                className="form-select w-full border border-gray-300 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              >
+                <option value="">Selecciona una fuente</option>
+                <option value="FONDOS_PUBLICOS">Fondos Públicos</option>
+                <option value="AUTOGESTION">Autogestión</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        {/* Origenes */}
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <MultiEventSelector
+            label="Eventos de origen (se reducirá su presupuesto)"
+            fuente={fuente}
+            selected={origenes}
+            onChange={setOrigenes}
+            excludeIds={origenExcludeIds}
+          />
+        </div>
+
+        {/* Destinos */}
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <MultiEventSelector
+            label="Eventos de destino (recibirán presupuesto)"
+            fuente={fuente}
+            selected={destinos}
+            onChange={setDestinos}
+            excludeIds={destinoExcludeIds}
+          />
+        </div>
+
+        {/* Balance bar */}
+        <BalanceBar totalCortado={totalCortado} totalAsignado={totalAsignado} />
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3">
+          <Link
+            href="/reformas-multi"
+            className="btn border-gray-200 text-gray-700 hover:border-gray-300 dark:border-gray-700/60 dark:text-gray-200 dark:hover:border-gray-600"
+          >
+            Cancelar
+          </Link>
+          <button
+            type="button"
+            disabled={!balanced || hasMontoErrors || mutation.isPending}
+            onClick={handleContinue}
+            className="btn bg-indigo-600 text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Continuar
+          </button>
+        </div>
+      </div>
+
+      {/* Confirm modal */}
+      <Transition.Root show={step === "confirm"} as={Fragment}>
+        <Dialog
+          as="div"
+          className="relative z-50"
+          role="dialog"
+          onClose={() => {
+            if (!mutation.isPending) setStep("form");
+          }}
+        >
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-200"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-150"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-gray-900/40 backdrop-blur-sm" />
+          </Transition.Child>
+
+          <div className="fixed inset-0 z-50 overflow-y-auto">
+            <div className="flex min-h-full items-center justify-center p-4">
+              <Transition.Child
+                as={Fragment}
+                enter="ease-out duration-200"
+                enterFrom="opacity-0 translate-y-2 scale-95"
+                enterTo="opacity-100 translate-y-0 scale-100"
+                leave="ease-in duration-150"
+                leaveFrom="opacity-100 translate-y-0 scale-100"
+                leaveTo="opacity-0 translate-y-2 scale-95"
+              >
+                <Dialog.Panel className="w-full max-w-lg transform overflow-hidden rounded-xl border border-gray-200 bg-white text-left align-middle shadow-xl transition-all dark:border-gray-700/60 dark:bg-gray-800">
+                  <div className="space-y-4 px-6 py-5">
+                    <Dialog.Title className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                      Confirmar solicitud
+                    </Dialog.Title>
+                    <Dialog.Description className="text-sm text-gray-600 dark:text-gray-300">
+                      Revisa el resumen antes de enviar la reforma.
+                    </Dialog.Description>
+
+                    {/* Summary */}
+                    <div className="space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm dark:border-gray-700 dark:bg-gray-900/40">
+                      <div>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">Motivo</p>
+                        <p className="font-medium text-gray-900 dark:text-gray-100">
+                          {motivo.trim()}
+                        </p>
+                      </div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <div>
+                          <p className="text-xs text-gray-500 dark:text-gray-400">Mes</p>
+                          <p className="font-medium text-gray-900 dark:text-gray-100">
+                            {mesEjecucion
+                              ? (MES_OPCIONES.find((m) => m.value === mesEjecucion)?.label ?? String(mesEjecucion))
+                              : "-"}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-gray-500 dark:text-gray-400">Fuente</p>
+                          <p className="font-medium text-gray-900 dark:text-gray-100">
+                            {fuente === "FONDOS_PUBLICOS"
+                              ? "Fondos Públicos"
+                              : fuente === "AUTOGESTION"
+                                ? "Autogestión"
+                                : "-"}
+                          </p>
+                        </div>
+                      </div>
+
+                      <div>
+                        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-rose-600 dark:text-rose-400">
+                          Orígenes
+                        </p>
+                        {origenes.map((e) => (
+                          <div
+                            key={e.eventoId}
+                            className="flex items-center justify-between text-xs"
+                          >
+                            <span className="truncate text-gray-700 dark:text-gray-300">
+                              {e.nombre} ({e.codigo})
+                            </span>
+                            <span className="ml-2 flex-shrink-0 font-medium text-rose-600 dark:text-rose-400">
+                              -{formatCurrency(e.monto)}
+                            </span>
+                          </div>
+                        ))}
+                        <div className="mt-1 flex justify-between border-t border-gray-200 pt-1 text-xs font-semibold dark:border-gray-700">
+                          <span className="text-gray-500 dark:text-gray-400">Total cortado</span>
+                          <span className="text-rose-600 dark:text-rose-400">
+                            -{formatCurrency(totalCortado)}
+                          </span>
+                        </div>
+                      </div>
+
+                      <div>
+                        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-400">
+                          Destinos
+                        </p>
+                        {destinos.map((e) => (
+                          <div
+                            key={e.eventoId}
+                            className="flex items-center justify-between text-xs"
+                          >
+                            <span className="truncate text-gray-700 dark:text-gray-300">
+                              {e.nombre} ({e.codigo})
+                            </span>
+                            <span className="ml-2 flex-shrink-0 font-medium text-emerald-600 dark:text-emerald-400">
+                              +{formatCurrency(e.monto)}
+                            </span>
+                          </div>
+                        ))}
+                        <div className="mt-1 flex justify-between border-t border-gray-200 pt-1 text-xs font-semibold dark:border-gray-700">
+                          <span className="text-gray-500 dark:text-gray-400">Total asignado</span>
+                          <span className="text-emerald-600 dark:text-emerald-400">
+                            +{formatCurrency(totalAsignado)}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="flex justify-end gap-2 border-t border-gray-200 bg-gray-50/60 px-6 py-4 dark:border-gray-700/60 dark:bg-gray-900/30">
+                    <button
+                      type="button"
+                      className="btn border-gray-200 text-gray-700 hover:border-gray-300 dark:border-gray-700/60 dark:text-gray-200 dark:hover:border-gray-600"
+                      onClick={() => setStep("form")}
+                      disabled={mutation.isPending}
+                    >
+                      Editar
+                    </button>
+                    <button
+                      type="button"
+                      className="btn bg-indigo-600 text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+                      onClick={handleConfirmSubmit}
+                      disabled={mutation.isPending}
+                    >
+                      {mutation.isPending ? "Enviando..." : "Confirmar y enviar"}
+                    </button>
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition.Root>
+    </div>
+  );
+}

--- a/app/(app)/reformas-multi/page.tsx
+++ b/app/(app)/reformas-multi/page.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Link from "next/link";
+import { Calendar, ClipboardList, Plus } from "lucide-react";
+
+import { useAuth } from "@/app/providers/auth-provider";
+import AlertBanner from "@/components/ui/alert-banner";
+import Pagination from "@/components/ui/pagination";
+import SearchInput from "@/components/ui/search-input";
+import { useResourceList } from "@/lib/hooks/use-resource-list";
+import {
+  listReformasMulti,
+  ESTADO_REFORMA_MULTI_LABELS,
+  FUENTE_REFORMA_LABELS,
+  MES_NOMBRES,
+  MES_OPCIONES,
+} from "@/lib/api/reforms-multi";
+import { canAccessReforms, canCreateReforma, getNormalizedRoles } from "@/lib/auth/access";
+import { formatDateTimeShort } from "@/lib/utils/formatters";
+import type { EstadoReformaMulti, ReformaMultiSummary } from "@/types/reforma-multi";
+
+const STATUS_STYLES: Record<string, string> = {
+  PENDIENTE:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200",
+  APROBADA:
+    "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200",
+  RECHAZADA:
+    "bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200",
+};
+
+function getStatusClasses(status?: string | null) {
+  if (!status) return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
+  return (
+    STATUS_STYLES[status.toUpperCase()] ??
+    "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+  );
+}
+
+const FUENTE_STYLES: Record<string, string> = {
+  FONDOS_PUBLICOS:
+    "bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200",
+  AUTOGESTION:
+    "bg-violet-100 text-violet-800 dark:bg-violet-900/40 dark:text-violet-200",
+};
+
+const LIMIT = 12;
+
+export default function ReformasMultiPage() {
+  const { user } = useAuth();
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [estado, setEstado] = useState<EstadoReformaMulti | "">("");
+  const [mesEjecucion, setMesEjecucion] = useState<number | "">("");
+
+  const canAccess = canAccessReforms(user);
+  const canCreate = canCreateReforma(user);
+  const roles = getNormalizedRoles(user);
+  const isPda = roles.includes("PDA");
+
+  const handleSearch = useCallback((value: string) => {
+    setSearch(value);
+    setPage(1);
+  }, []);
+
+  const {
+    items: reforms,
+    loading: isLoading,
+    error,
+    totalPages,
+  } = useResourceList<ReformaMultiSummary>({
+    queryKey: ["reformas-multi", page, search, estado, mesEjecucion],
+    queryFn: () =>
+      listReformasMulti({
+        page,
+        limit: LIMIT,
+        search: search || undefined,
+        estado: estado || undefined,
+        mesEjecucion: mesEjecucion || undefined,
+      }),
+    page,
+    limit: LIMIT,
+    enabled: canAccess,
+  });
+
+  if (!canAccess) {
+    return (
+      <div className="px-4 sm:px-6 lg:px-8 py-8 w-full max-w-7xl mx-auto">
+        <AlertBanner
+          variant="error"
+          message="No tienes permisos para ver reformas multi-evento."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-8 w-full max-w-7xl mx-auto">
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              Reformas Multi-Evento
+            </h1>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Solicitudes de transferencia presupuestaria entre múltiples eventos (N→M).
+            </p>
+          </div>
+          {(canCreate || isPda) && (
+            <Link
+              href="/reformas-multi/nueva"
+              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 transition"
+            >
+              <Plus className="h-4 w-4" />
+              Nueva solicitud
+            </Link>
+          )}
+        </div>
+
+        {error ? (
+          <AlertBanner
+            variant="error"
+            message={error ?? "Error al cargar reformas."}
+          />
+        ) : null}
+
+        {/* Filters */}
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <SearchInput
+            value={search}
+            onChange={handleSearch}
+            placeholder="Buscar por motivo o número..."
+            className="sm:w-72"
+          />
+          <select
+            value={estado}
+            onChange={(e) => {
+              setEstado((e.target.value as EstadoReformaMulti) || "");
+              setPage(1);
+            }}
+            className="rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 outline-none transition focus:border-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-gray-300"
+          >
+            <option value="">Todos los estados</option>
+            <option value="PENDIENTE">Pendiente</option>
+            <option value="APROBADA">Aprobada</option>
+            <option value="RECHAZADA">Rechazada</option>
+          </select>
+          <select
+            value={mesEjecucion}
+            onChange={(e) => {
+              setMesEjecucion(e.target.value ? Number(e.target.value) : "");
+              setPage(1);
+            }}
+            className="rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 outline-none transition focus:border-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-gray-300"
+          >
+            <option value="">Todos los meses</option>
+            {MES_OPCIONES.map((mes) => (
+              <option key={mes.value} value={mes.value}>
+                {mes.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* List */}
+        {isLoading ? (
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="animate-pulse rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+              >
+                <div className="mb-3 h-4 w-28 rounded bg-gray-200 dark:bg-gray-700" />
+                <div className="mb-2 h-5 w-3/4 rounded bg-gray-200 dark:bg-gray-700" />
+                <div className="h-4 w-1/2 rounded bg-gray-200 dark:bg-gray-700" />
+              </div>
+            ))}
+          </div>
+        ) : reforms.length === 0 ? (
+          <div className="rounded-xl border border-gray-200 bg-white p-10 text-center shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-300">
+              <ClipboardList className="h-7 w-7" />
+            </div>
+            <h2 className="mt-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+              No hay reformas para mostrar
+            </h2>
+            <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+              Ajusta los filtros o crea una nueva solicitud.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {reforms.map((reform) => (
+              <article
+                key={reform.id}
+                className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+              >
+                <div className="mb-4 flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Reforma Multi #{reform.id}
+                    </p>
+                    <h2
+                      className="mt-1 line-clamp-2 text-sm font-semibold text-gray-900 dark:text-gray-100"
+                      title={reform.motivo}
+                    >
+                      {reform.motivo}
+                    </h2>
+                  </div>
+                  <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
+                    <span
+                      className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${getStatusClasses(reform.estado)}`}
+                    >
+                      {ESTADO_REFORMA_MULTI_LABELS[reform.estado] ?? reform.estado}
+                    </span>
+                    <span
+                      className={`inline-flex rounded-full px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+                        FUENTE_STYLES[reform.fuente] ??
+                        "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+                      }`}
+                    >
+                      {FUENTE_REFORMA_LABELS[reform.fuente] ?? reform.fuente}
+                    </span>
+                  </div>
+                </div>
+
+                <dl className="space-y-2 text-sm">
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <dt className="text-xs text-gray-500 dark:text-gray-400">Orígenes</dt>
+                      <dd className="mt-0.5 font-medium text-gray-900 dark:text-gray-100">
+                        {reform.origenes.length} evento{reform.origenes.length !== 1 ? "s" : ""}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-gray-500 dark:text-gray-400">Destinos</dt>
+                      <dd className="mt-0.5 font-medium text-gray-900 dark:text-gray-100">
+                        {reform.destinos.length} evento{reform.destinos.length !== 1 ? "s" : ""}
+                      </dd>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <dt className="text-xs text-gray-500 dark:text-gray-400">Mes</dt>
+                      <dd className="mt-0.5 inline-flex items-center gap-1 font-medium text-gray-900 dark:text-gray-100">
+                        <Calendar className="h-3 w-3 text-gray-400" />
+                        {MES_NOMBRES[reform.mesEjecucion] ?? `Mes ${reform.mesEjecucion}`}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-gray-500 dark:text-gray-400">Solicitante</dt>
+                      <dd className="mt-0.5 truncate font-medium text-gray-900 dark:text-gray-100">
+                        {reform.solicitante.nombre} {reform.solicitante.apellido}
+                      </dd>
+                    </div>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500 dark:text-gray-400">Fecha</dt>
+                    <dd className="mt-0.5 text-gray-700 dark:text-gray-300">
+                      {formatDateTimeShort(reform.createdAt)}
+                    </dd>
+                  </div>
+                </dl>
+
+                <div className="mt-4 border-t border-gray-100 pt-3 dark:border-gray-700/60">
+                  <Link
+                    href={`/reformas-multi/${reform.id}`}
+                    className="text-sm font-medium text-indigo-600 transition hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+                  >
+                    Ver detalle
+                  </Link>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <Pagination
+            currentPage={page}
+            totalPages={totalPages}
+            onPageChange={setPage}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/api/reforms-multi.ts
+++ b/lib/api/reforms-multi.ts
@@ -1,0 +1,111 @@
+import { apiFetch } from "@/lib/api/client";
+import type {
+  ReformaMultiSummary,
+  ReformaMultiDetail,
+  ListReformasMultiQuery,
+  CreateReformaMultiPayload,
+} from "@/types/reforma-multi";
+
+export async function listReformasMulti(query: ListReformasMultiQuery = {}) {
+  const params = new URLSearchParams();
+  if (query.page) params.set("page", String(query.page));
+  if (query.limit) params.set("limit", String(query.limit));
+  if (query.estado) params.set("estado", query.estado);
+  if (query.mesEjecucion) params.set("mesEjecucion", String(query.mesEjecucion));
+  if (query.search) params.set("search", query.search);
+
+  const qs = params.toString();
+  const url = qs ? `/reforms-multi?${qs}` : "/reforms-multi";
+
+  return apiFetch<ReformaMultiSummary[]>(url, { method: "GET" });
+}
+
+export async function getReformaMulti(id: number) {
+  return apiFetch<ReformaMultiDetail>(`/reforms-multi/${id}`, { method: "GET" });
+}
+
+export async function createReformaMulti(payload: CreateReformaMultiPayload) {
+  return apiFetch<ReformaMultiDetail>("/reforms-multi", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function aprobarReformaMulti(id: number) {
+  return apiFetch<ReformaMultiDetail>(`/reforms-multi/${id}/aprobar`, {
+    method: "PATCH",
+  });
+}
+
+export async function rechazarReformaMulti(id: number, observacion: string) {
+  return apiFetch<ReformaMultiDetail>(`/reforms-multi/${id}/rechazar`, {
+    method: "PATCH",
+    body: JSON.stringify({ observacion }),
+  });
+}
+
+export const ESTADO_REFORMA_MULTI_LABELS: Record<string, string> = {
+  PENDIENTE: "Pendiente",
+  APROBADA: "Aprobada",
+  RECHAZADA: "Rechazada",
+};
+
+export const FUENTE_REFORMA_LABELS: Record<string, string> = {
+  FONDOS_PUBLICOS: "Fondos Públicos",
+  AUTOGESTION: "Autogestión",
+};
+
+export const MES_NOMBRES: Record<number, string> = {
+  1: "Enero",
+  2: "Febrero",
+  3: "Marzo",
+  4: "Abril",
+  5: "Mayo",
+  6: "Junio",
+  7: "Julio",
+  8: "Agosto",
+  9: "Septiembre",
+  10: "Octubre",
+  11: "Noviembre",
+  12: "Diciembre",
+};
+
+export const MES_OPCIONES = Array.from({ length: 12 }, (_, i) => ({
+  value: i + 1,
+  label: MES_NOMBRES[i + 1],
+}));
+
+export const ERROR_CODE_MESSAGES: Record<string, string> = {
+  REFORMA_MULTI_NOT_FOUND: "La reforma no fue encontrada.",
+  REFORMA_MULTI_NOT_PENDING: "La reforma no está en estado pendiente.",
+  REFORMA_MULTI_ALREADY_APPROVED: "La reforma ya fue aprobada.",
+  REFORMA_MULTI_SUM_MISMATCH:
+    "La suma de montos de origen no coincide con la de destino.",
+  REFORMA_MULTI_MIXED_SOURCE:
+    "Todos los eventos deben tener la misma fuente presupuestaria.",
+  REFORMA_MULTI_ORIGEN_LOCKED:
+    "Uno o más eventos de origen están bloqueados por otra reforma pendiente.",
+  REFORMA_MULTI_INSUFFICIENT_FUNDS:
+    "Fondos insuficientes en uno o más eventos de origen.",
+  REFORMA_MULTI_BELOW_COMMITTED:
+    "El corte dejaría el presupuesto por debajo del monto comprometido.",
+  REFORMA_MULTI_PERMISSION:
+    "No tienes permiso para realizar esta operación.",
+  REFORMA_MULTI_REJECTION_REASON_REQUIRED:
+    "Debes indicar una observación para el rechazo.",
+};
+
+export function getErrorMessage(
+  err: unknown,
+  fallback = "Ocurrió un error inesperado.",
+): string {
+  if (err instanceof Error) {
+    const code = (err as Error & { problem?: { errorCode?: string } }).problem
+      ?.errorCode;
+    if (code && ERROR_CODE_MESSAGES[code]) {
+      return ERROR_CODE_MESSAGES[code];
+    }
+    return err.message || fallback;
+  }
+  return fallback;
+}

--- a/lib/navigation/sidebar.config.ts
+++ b/lib/navigation/sidebar.config.ts
@@ -118,6 +118,14 @@ export const SIDEBAR_ITEMS: SidebarItem[] = [
   },
   {
     type: "link",
+    label: "Reformas Multi",
+    href: "/reformas-multi",
+    segment: "reformas-multi",
+    icon: "reformas",
+    roles: ["SUPER_ADMIN", "ADMIN", "PDA", "ENTRENADOR", "DTM", "DTM_EIDE"],
+  },
+  {
+    type: "link",
     label: "Carga Masiva",
     href: "/carga-masiva",
     segment: "carga-masiva",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^5.100.14",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "decimal.js": "^10.6.0",
     "lucide-react": "^0.561.0",
     "next": "^16.0.10",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      decimal.js:
+        specifier: ^10.6.0
+        version: 10.6.0
       lucide-react:
         specifier: ^0.561.0
         version: 0.561.0(react@19.2.4)
@@ -1378,6 +1381,9 @@ packages:
 
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -3813,6 +3819,8 @@ snapshots:
       ms: 2.1.3
 
   decimal.js-light@2.5.1: {}
+
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 

--- a/types/reforma-multi.ts
+++ b/types/reforma-multi.ts
@@ -1,0 +1,88 @@
+export type FuentePresupuestoReforma = "FONDOS_PUBLICOS" | "AUTOGESTION";
+export type EstadoReformaMulti = "PENDIENTE" | "APROBADA" | "RECHAZADA";
+
+export type UsuarioResumen = {
+  id: number;
+  nombre: string;
+  apellido: string;
+  email: string;
+};
+
+export type DisciplinaResumen = {
+  id: number;
+  nombre: string;
+};
+
+export type EventoResumen = {
+  id: number;
+  codigo: string;
+  nombre: string;
+  disciplina?: DisciplinaResumen;
+};
+
+export type EventoOrigenItem = {
+  id: number;
+  eventoId: number;
+  montoCortado: string;
+  totalEventoAntes: string;
+  totalEventoDespues?: string | null;
+  evento: EventoResumen;
+};
+
+export type EventoDestinoItem = {
+  id: number;
+  eventoId: number;
+  montoAsignado: string;
+  totalEventoAntes: string;
+  totalEventoDespues?: string | null;
+  evento: EventoResumen;
+};
+
+export type CambiosSnapshot = {
+  origenes: Array<{
+    eventoId: number;
+    before: Array<{ itemId: number; presupuesto: string }>;
+    after: Array<{ itemId: number; presupuesto: string }>;
+  }>;
+  destinos: Array<{
+    eventoId: number;
+    before: Array<{ itemId: number; presupuesto: string }>;
+    after: Array<{ itemId: number; presupuesto: string }>;
+  }>;
+};
+
+export type ReformaMultiSummary = {
+  id: number;
+  motivo: string;
+  mesEjecucion: number;
+  estado: EstadoReformaMulti;
+  fuente: FuentePresupuestoReforma;
+  observacion?: string | null;
+  solicitante: UsuarioResumen;
+  aprobador?: UsuarioResumen | null;
+  reviewedAt?: string | null;
+  origenes: EventoOrigenItem[];
+  destinos: EventoDestinoItem[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ReformaMultiDetail = ReformaMultiSummary & {
+  cambios?: CambiosSnapshot | null;
+};
+
+export type ListReformasMultiQuery = {
+  page?: number;
+  limit?: number;
+  estado?: EstadoReformaMulti;
+  mesEjecucion?: number;
+  search?: string;
+};
+
+export type CreateReformaMultiPayload = {
+  motivo: string;
+  mesEjecucion: number;
+  fuente: FuentePresupuestoReforma;
+  eventosOrigen: Array<{ eventoId: number; monto: number }>;
+  eventosDestino: Array<{ eventoId: number; monto: number }>;
+};


### PR DESCRIPTION
## Summary

Adds the **frontend UI for multi-event budget reforms (N→M)** under `/reformas-multi`. Pairs with backend PR [`feat/reforma-multi-evento-backend`](https://github.com/Soffiweb/Avales-backend/pull/69) — merge the backend first (or deploy the migration alongside).

- **`/reformas-multi`** — list with TanStack Query, `estado` + `mesEjecucion` filters, debounced search, paginator. Uses the canonical `useResourceList` hook (same pattern as `deportistas`/`eventos`).
- **`/reformas-multi/[id]`** — detail with side-by-side origenes/destinos, before/after item snapshots reconstructed from the `cambios` JSON, aprobar/rechazar buttons role-gated (PDA, ADMIN, SUPER_ADMIN). Reject flow uses a modal with `observacion` textarea (1–600 chars).
- **`/reformas-multi/nueva`** — multi-step creation form composed of `MultiEventSelector` + `BalanceBar`, with a pre-submit confirm modal listing every event and monto. Gated by ENTRENADOR (with `puedeSolicitarReformas`), ADMIN, or SUPER_ADMIN.

### New components

- `multi-event-selector.tsx` — debounced `SearchInput`, client-side filter by `fuente` (events endpoint doesn't yet expose a server-side `fuente` filter; backend `validateSameSource` catches mismatches at create time), selected events as removable chips, per-event monto input with inline solvency hints.
- `balance-bar.tsx` — live \"Total cortado / Total a distribuir / Balance\" display computed with **`decimal.js`** to avoid float drift; exposes a `submit-disabled` prop when imbalanced.

### API + types

- `types/reforma-multi.ts` — TypeScript interfaces mirroring the backend `ReformaMultiResponseDto`.
- `lib/api/reforms-multi.ts` — BFF-proxy functions (`listReformasMulti`, `getReformaMulti`, `createReformaMulti`, `aprobarReformaMulti`, `rechazarReformaMulti`) plus error-code → friendly Spanish message map (`REFORMA_MULTI_*`).

### Sidebar

- New \"Reformas Multi\" entry. Reuses the existing `reformas` icon key since no dedicated `reformasMulti` key exists in `SidebarIconKey`.

### Dependencies

- `decimal.js@10.6.0` added for client-side balance arithmetic without float drift.

### Verification

- \`npx tsc --noEmit\`: clean.
- \`pnpm lint\`: 107 problems (matches baseline — zero new errors in the slice files).

### Notes from SDD verify

The verify report flagged a pagination key mismatch (backend returned `meta`, frontend read `pagination`) — **fixed in this PR** by refactoring the list page to use the canonical `useResourceList` hook and aligning `lib/api/reforms-multi.ts` to return `apiFetch<ReformaMultiSummary[]>` (the interceptor flattens pagination into the response `meta`).

## Test plan

- [ ] Backend PR merged and migration deployed before exercising flows.
- [ ] Sidebar shows the \"Reformas Multi\" entry for authorized roles.
- [ ] List page: pagination works (multiple pages), \`estado\` and \`mesEjecucion\` filters update results, debounced search hits the backend correctly.
- [ ] Detail page: PENDIENTE shows aprobar/rechazar buttons for PDA/ADMIN/SUPER_ADMIN only; APROBADA shows before/after items reconstructed from `cambios`.
- [ ] Create flow (entrenador with `puedeSolicitarReformas`):
  - [ ] Pick 2 origenes + 3 destinos, montos balanceados → submit OK → redirect to detail.
  - [ ] Mixed `fuente` between origin and destination → backend rejects with `REFORMA_MULTI_MIXED_SOURCE` → friendly message in UI.
  - [ ] Unbalanced sums → submit button disabled, BalanceBar shows ✗.
  - [ ] Same event in both columns → confirm modal warns / backend rejects 422 → friendly message in UI.
- [ ] Reject flow: empty observacion blocked; valid observacion (1–600 chars) → state RECHAZADA, email fires.
- [ ] Approve flow: state APROBADA, items recomputed, `cambios` JSON shown in detail, PDFs regen visible in respective events.
- [ ] Dark-mode rendering for all three pages (list / detail / nueva).