### PR TITLE
feat(avales): modal de documentos — vista previa y descarga combinada

### DIFF
--- a/app/(app)/avales/[id]/_components/aval-pdf-composer-modal.tsx
+++ b/app/(app)/avales/[id]/_components/aval-pdf-composer-modal.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Download, ExternalLink, Loader2, X } from "lucide-react";
+
+import AlertBanner from "@/components/ui/alert-banner";
+import {
+  DOCUMENT_LABELS,
+  PREVIEW_ENDPOINTS,
+  downloadComposedPdf,
+  openAvalPdfPreview,
+  type ComposableDocumentKey,
+} from "@/lib/api/aval-pdfs";
+
+type Props = {
+  avalId: number;
+  /** Mapa documento → URL (o null si no existe). El user solo puede marcar los que tienen URL. */
+  availableDocs: Partial<Record<ComposableDocumentKey, string | null>>;
+  onClose: () => void;
+};
+
+const DOC_ORDER: ComposableDocumentKey[] = [
+  "convocatoria",
+  "certificadoMedico",
+  "pronosticoDeportistas",
+  "escuelaIniciacion",
+  "avalTecnico",
+  "comprasPublicas",
+  "revisionMetodologo",
+  "revisionDtm",
+  "controlPrevio",
+  "presupuestoSalida",
+  "certificacionPresupuestaria",
+];
+
+export default function AvalPdfComposerModal({
+  avalId,
+  availableDocs,
+  onClose,
+}: Props) {
+  const [selected, setSelected] = useState<Set<ComposableDocumentKey>>(
+    new Set(),
+  );
+  const [previewing, setPreviewing] = useState<ComposableDocumentKey | null>(
+    null,
+  );
+  const [downloading, setDownloading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const rows = useMemo(
+    () =>
+      DOC_ORDER.map((key) => {
+        const url = availableDocs[key];
+        const available = Boolean(url);
+        return { key, available, hasPreview: !!PREVIEW_ENDPOINTS[key] };
+      }),
+    [availableDocs],
+  );
+
+  function toggle(key: ComposableDocumentKey) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  async function handlePreview(key: ComposableDocumentKey) {
+    setError(null);
+    setPreviewing(key);
+    try {
+      await openAvalPdfPreview(avalId, key);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "No se pudo abrir la vista previa");
+    } finally {
+      setPreviewing(null);
+    }
+  }
+
+  async function handleDownload() {
+    if (selected.size === 0) return;
+    setError(null);
+    setDownloading(true);
+    try {
+      await downloadComposedPdf(avalId, Array.from(selected));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "No se pudo descargar el PDF");
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+      <div className="w-full max-w-2xl rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-900 max-h-[90vh] overflow-y-auto">
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              Documentos del aval
+            </h2>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Vista previa individual o descarga combinada en un solo PDF.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+            aria-label="Cerrar"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {error ? (
+          <div className="mb-4">
+            <AlertBanner variant="error" message={error} />
+          </div>
+        ) : null}
+
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700 rounded-lg border border-gray-200 dark:border-gray-700">
+          {rows.map(({ key, available, hasPreview }) => (
+            <li
+              key={key}
+              className={`flex items-center gap-3 px-3 py-2.5 ${
+                available
+                  ? ""
+                  : "opacity-60"
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(key)}
+                onChange={() => toggle(key)}
+                disabled={!available}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <label className="flex-1 text-sm text-gray-800 dark:text-gray-200 select-none cursor-pointer" onClick={() => available && toggle(key)}>
+                {DOCUMENT_LABELS[key]}
+                {!available ? (
+                  <span className="ml-2 text-xs text-gray-400">
+                    (sin archivo)
+                  </span>
+                ) : null}
+              </label>
+              {available && hasPreview ? (
+                <button
+                  onClick={() => handlePreview(key)}
+                  disabled={previewing === key}
+                  className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 disabled:opacity-60"
+                  title="Abrir vista previa en otra pestaña"
+                >
+                  {previewing === key ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <ExternalLink className="h-3 w-3" />
+                  )}
+                  Ver
+                </button>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={handleDownload}
+            disabled={selected.size === 0 || downloading}
+            className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:opacity-60"
+          >
+            {downloading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="h-4 w-4" />
+            )}
+            Descargar PDF compuesto
+            {selected.size > 0 ? ` (${selected.size})` : ""}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/avales/[id]/page.tsx
+++ b/app/(app)/avales/[id]/page.tsx
@@ -38,6 +38,7 @@ import ConfirmModal from "@/components/ui/confirm-modal";
 import AvalPresupuestoSection from "./_components/aval-presupuesto-section";
 import AvalDeportistasSection from "./_components/aval-deportistas-section";
 import AvalLogisticaSection from "./_components/aval-logistica-section";
+import AvalPdfComposerModal from "./_components/aval-pdf-composer-modal";
 import Breadcrumb from "@/components/ui/breadcrumb";
 import { useAuth } from "@/app/providers/auth-provider";
 import {
@@ -691,6 +692,7 @@ export default function AvalDetailPage() {
   const [deletingRequest, setDeletingRequest] = useState(false);
   const [regenerating, setRegenerating] = useState(false);
   const [downloadingAval, setDownloadingAval] = useState(false);
+  const [composerOpen, setComposerOpen] = useState(false);
 
   const userRoles = getNormalizedRoles(user);
   const isAdminLike =
@@ -1128,6 +1130,15 @@ export default function AvalDetailPage() {
                 {regenerating ? "Iniciando..." : "Regenerar PDFs"}
               </button>
             )}
+            <button
+              type="button"
+              onClick={() => setComposerOpen(true)}
+              className="btn border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+              title="Vista previa o descarga combinada de documentos"
+            >
+              <FileText className="w-4 h-4 mr-2" />
+              Documentos del aval
+            </button>
             {canDownloadAvalCompleto ? (
               <button
                 type="button"
@@ -1734,6 +1745,26 @@ export default function AvalDetailPage() {
             />
           </CollapsibleSection>
         </div>
+      ) : null}
+
+      {composerOpen ? (
+        <AvalPdfComposerModal
+          avalId={aval.id}
+          availableDocs={{
+            avalTecnico: aval.avalTecnicoPdfUrl,
+            comprasPublicas: aval.comprasPublicasPdfUrl,
+            revisionMetodologo: aval.revisionMetodologoUrl,
+            revisionDtm: aval.revisionDtmUrl,
+            controlPrevio: aval.controlPrevioUrl,
+            presupuestoSalida: aval.presupuestoSalidaUrl,
+            certificacionPresupuestaria: aval.certificacionPresupuestariaUrl,
+            escuelaIniciacion: aval.escuelaIniciacionPdfUrl,
+            convocatoria: aval.convocatoriaUrl,
+            certificadoMedico: aval.certificadoMedicoUrl,
+            pronosticoDeportistas: aval.pronosticoDeportistasUrl,
+          }}
+          onClose={() => setComposerOpen(false)}
+        />
       ) : null}
 
       <ConfirmModal

--- a/lib/api/aval-pdfs.ts
+++ b/lib/api/aval-pdfs.ts
@@ -1,0 +1,116 @@
+import { ensureFreshAccessToken } from "@/lib/api/client";
+import { getAccessToken } from "@/lib/auth/tokens";
+
+const API_BASE = "/api/v1";
+
+export type ComposableDocumentKey =
+  | "avalTecnico"
+  | "comprasPublicas"
+  | "revisionMetodologo"
+  | "revisionDtm"
+  | "controlPrevio"
+  | "presupuestoSalida"
+  | "certificacionPresupuestaria"
+  | "escuelaIniciacion"
+  | "convocatoria"
+  | "certificadoMedico"
+  | "pronosticoDeportistas";
+
+export const DOCUMENT_LABELS: Record<ComposableDocumentKey, string> = {
+  avalTecnico: "Aval técnico",
+  comprasPublicas: "Certificado compras públicas",
+  revisionMetodologo: "Revisión metodólogo",
+  revisionDtm: "Revisión DTM",
+  controlPrevio: "Control previo",
+  presupuestoSalida: "Presupuesto salida deportistas",
+  certificacionPresupuestaria: "Certificación presupuestaria",
+  escuelaIniciacion: "Escuela de iniciación",
+  convocatoria: "Convocatoria",
+  certificadoMedico: "Certificado médico",
+  pronosticoDeportistas: "Pronóstico deportistas",
+};
+
+/**
+ * Mapea cada documento composable al endpoint GET que genera su preview
+ * on-the-fly (sin cambiar estado). null = no hay preview directo
+ * (ej. el cert PDA fue removido; usar `presupuestoSalida` del financiero).
+ */
+export const PREVIEW_ENDPOINTS: Record<
+  ComposableDocumentKey,
+  string | null
+> = {
+  avalTecnico: "/aval-tecnico-pdf",
+  comprasPublicas: "/compras-publicas-pdf",
+  revisionMetodologo: "/revision-metodologo-pdf",
+  revisionDtm: "/revision-dtm-pdf",
+  controlPrevio: "/control-previo-pdf",
+  presupuestoSalida: "/financiero-pdf",
+  certificacionPresupuestaria: "/financiero-pdf",
+  escuelaIniciacion: "/escuela-iniciacion-pdf",
+  convocatoria: null,
+  certificadoMedico: null,
+  pronosticoDeportistas: null,
+};
+
+async function buildAuthHeader(): Promise<Record<string, string>> {
+  await ensureFreshAccessToken();
+  const token = getAccessToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * Abre el PDF preview del paso indicado en una nueva pestaña.
+ * Usa fetch para inyectar el Bearer token y luego `window.open` con un blob URL.
+ */
+export async function openAvalPdfPreview(
+  avalId: number,
+  key: ComposableDocumentKey,
+): Promise<void> {
+  const endpoint = PREVIEW_ENDPOINTS[key];
+  if (!endpoint) {
+    throw new Error(
+      `No hay endpoint de preview directo para "${DOCUMENT_LABELS[key]}".`,
+    );
+  }
+  const url = `${API_BASE}/avales/${avalId}${endpoint}`;
+  const headers = await buildAuthHeader();
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(`No se pudo cargar el PDF (HTTP ${res.status})`);
+  }
+  const blob = await res.blob();
+  const blobUrl = URL.createObjectURL(blob);
+  window.open(blobUrl, "_blank", "noopener,noreferrer");
+}
+
+/**
+ * Pide al backend componer un PDF con los documentos seleccionados y
+ * dispara la descarga al cliente.
+ */
+export async function downloadComposedPdf(
+  avalId: number,
+  documentos: ComposableDocumentKey[],
+): Promise<void> {
+  const url = `${API_BASE}/avales/${avalId}/compose-pdf`;
+  const authHeaders = await buildAuthHeader();
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeaders,
+    },
+    body: JSON.stringify({ documentos }),
+  });
+  if (!res.ok) {
+    throw new Error(`No se pudo componer el PDF (HTTP ${res.status})`);
+  }
+  const blob = await res.blob();
+  const blobUrl = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = blobUrl;
+  link.download = `aval-${avalId}-compuesto.pdf`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(blobUrl);
+}

--- a/types/aval.ts
+++ b/types/aval.ts
@@ -263,6 +263,12 @@ export type Aval = {
   pronosticoDeportistasUrl?: string | null;
   avalTecnicoPdfUrl?: string | null;
   escuelaIniciacionPdfUrl?: string | null;
+  comprasPublicasPdfUrl?: string | null;
+  revisionMetodologoUrl?: string | null;
+  revisionDtmUrl?: string | null;
+  controlPrevioUrl?: string | null;
+  presupuestoSalidaUrl?: string | null;
+  certificacionPresupuestariaUrl?: string | null;
   dtmUrl?: string | null;
   pdaUrl?: string | null;
   solicitudUrl?: string | null;


### PR DESCRIPTION
## Summary

Modal único en la página detalle del aval que resuelve los **items 5 y 6** de Xavier:

- **Item 5** — Vista previa de cualquier PDF del flujo (aval técnico, compras públicas, revisión metodólogo, revisión DTM, control previo, financiero) en una pestaña nueva, sin cambiar estado del aval.
- **Item 6** — Marcar varios documentos con checkboxes y recibir un único PDF concatenado.

Pareja del backend PR [`Soffiweb/Avales-backend#74`](https://github.com/Soffiweb/Avales-backend/pull/74).

### UI

Botón nuevo **\"Documentos del aval\"** junto a \"Descargar aval completo\" y \"Regenerar PDFs\" en el header de la página detalle. Abre un modal con la lista ordenada por orden lógico del flujo:

1. Convocatoria
2. Certificado médico
3. Pronóstico deportistas
4. Escuela de iniciación
5. Aval técnico
6. Certificado compras públicas
7. Revisión metodólogo
8. Revisión DTM
9. Control previo
10. Presupuesto salida deportistas
11. Certificación presupuestaria

Cada fila tiene:
- Checkbox (disabled si el documento aún no se generó).
- Botón \"Ver\" (vista previa en pestaña nueva, solo para docs con endpoint GET directo).

Footer:
- \"Cancelar\" cierra el modal.
- \"Descargar PDF compuesto (N)\" envía la lista seleccionada al backend y dispara la descarga.

### Archivos

- `lib/api/aval-pdfs.ts` — utilidades fetch con Bearer token (`openAvalPdfPreview`, `downloadComposedPdf`).
- `app/(app)/avales/[id]/_components/aval-pdf-composer-modal.tsx` — componente modal.
- `app/(app)/avales/[id]/page.tsx` — botón + render condicional del modal.
- `types/aval.ts` — agregadas 6 URL columns que faltaban en el tipo (`comprasPublicasPdfUrl`, `revisionMetodologoUrl`, `revisionDtmUrl`, `controlPrevioUrl`, `presupuestoSalidaUrl`, `certificacionPresupuestariaUrl`).

### Orden de mergeo

Backend [`#74`](https://github.com/Soffiweb/Avales-backend/pull/74) primero → este PR (la descarga combinada requiere el endpoint nuevo).

### Verificación

- `npx tsc --noEmit`: cero errores nuevos.
- `pnpm lint`: cero errores en archivos nuevos.

## Test plan

- [ ] Aval con todos los documentos generados → modal muestra todas las filas habilitadas.
- [ ] Aval sin algunos documentos → esas filas aparecen disabled con \"(sin archivo)\".
- [ ] Click \"Ver\" en aval técnico → abre PDF en pestaña nueva.
- [ ] Click \"Ver\" en convocatoria (sin endpoint preview) → no muestra botón \"Ver\".
- [ ] Marcar 3 docs + \"Descargar PDF compuesto (3)\" → recibe PDF con esas 3 secciones concatenadas.
- [ ] Sin nada seleccionado → botón disabled.
- [ ] Error de red → AlertBanner en el modal.
- [ ] Dark mode renderiza correctamente.