### PR TITLE
feat(nav): agregar entrada "Roles" en el sidebar

### DIFF
--- a/components/icons/sidebar-icons.tsx
+++ b/components/icons/sidebar-icons.tsx
@@ -9,6 +9,7 @@ import {
   FolderKanban,
   History,
   ShieldAlert,
+  ShieldCheck,
 } from "lucide-react";
 
 export const SidebarIcons = {
@@ -22,6 +23,7 @@ export const SidebarIcons = {
   catalogos: FolderKanban,
   miHistorial: History,
   monitoreo: ShieldAlert,
+  roles: ShieldCheck,
 };
 
 export type SidebarIconKey = keyof typeof SidebarIcons;

--- a/lib/navigation/sidebar.config.ts
+++ b/lib/navigation/sidebar.config.ts
@@ -68,6 +68,14 @@ export const SIDEBAR_ITEMS: SidebarItem[] = [
   },
   {
     type: "link",
+    label: "Roles",
+    href: "/roles",
+    segment: "roles",
+    icon: "roles",
+    roles: ["SUPER_ADMIN", "ADMIN"],
+  },
+  {
+    type: "link",
     label: "Avales",
     href: "/avales",
     segment: "avales",


### PR DESCRIPTION
## Summary

Después del merge del PR #34 (Admin Roles UI) quedó la página `/roles` accesible pero **sin link en el sidebar**. Había que escribir la URL a mano. Tenés razón — no era intencional.

### Cambios

- `components/icons/sidebar-icons.tsx`: nueva key `roles` con icono `ShieldCheck` de lucide.
- `lib/navigation/sidebar.config.ts`: entrada nueva debajo de \"Usuarios\":

\`\`\`ts
{
  type: \"link\",
  label: \"Roles\",
  href: \"/roles\",
  segment: \"roles\",
  icon: \"roles\",
  roles: [\"SUPER_ADMIN\", \"ADMIN\"],
},
\`\`\`

Mismo gate de roles que \"Usuarios\".

### Verificación

- `npx tsc --noEmit`: cero errores nuevos.

## Test plan

- [ ] Login como SUPER_ADMIN → ver \"Roles\" en el sidebar con icono de escudo.
- [ ] Click → navega a `/roles` (tabla de roles editables).
- [ ] Login como ENTRENADOR → la entrada \"Roles\" NO aparece en el sidebar.
- [ ] Login como DTM → tampoco aparece.