### PR TITLE
fix(eventos): items presupuestarios anidados por forma de participacion

### DIFF
--- a/app/(app)/eventos/[id]/page.tsx
+++ b/app/(app)/eventos/[id]/page.tsx
@@ -758,7 +758,19 @@ export default function EventoDetailPage() {
                       </p>
                     ) : (
                       <div className="space-y-6">
-                        {formasPorTipo.map((forma) => {
+                        {formasPorTipo.map((forma, formaIndex) => {
+                          const avalesDeForma = avalesEvento.filter((aval) => {
+                            const formaVinculadaId =
+                              aval.evento?.formaParticipacionActual?.id;
+                            if (formaVinculadaId != null) {
+                              return formaVinculadaId === forma.id;
+                            }
+                            // Avales legado sin forma vinculada: solo listar aquí si
+                            // no hay ambigüedad (única forma de este tipo).
+                            return (
+                              formasPorTipo.length === 1 && aval.tipoAval === tipoAval
+                            );
+                          });
                           const totalAtletas =
                             forma.numAtletasHombres + forma.numAtletasMujeres;
                           const totalEntrenadores =
@@ -794,7 +806,20 @@ export default function EventoDetailPage() {
                           const sinFinanciamiento = forma.tipoAval === "SOLO_RESULTADO";
 
                           return (
-                            <div key={forma.id} className="space-y-4">
+                            <div
+                              key={forma.id}
+                              className="space-y-4 rounded-2xl border-2 border-gray-200 bg-gray-50/60 p-5 dark:border-gray-700 dark:bg-gray-900/20"
+                            >
+                              {formasPorTipo.length > 1 && (
+                                <div className="flex items-center gap-2">
+                                  <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-900 text-xs font-bold text-white dark:bg-gray-100 dark:text-gray-900">
+                                    {formaIndex + 1}
+                                  </span>
+                                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                    Participación {formaIndex + 1} de {formasPorTipo.length}
+                                  </span>
+                                </div>
+                              )}
                               <div className="grid gap-4 lg:grid-cols-[1fr_1.4fr_1.2fr]">
                                 <div className="rounded-xl border border-gray-100 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
                                   <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">Referencia</p>
@@ -912,15 +937,12 @@ export default function EventoDetailPage() {
                                   </div>
                                 )}
                               </div>
-                            </div>
-                          );
-                        })}
 
-                        <div>
-                          <h3 className="mb-3 text-sm font-semibold text-gray-900 dark:text-gray-100">Avales</h3>
-                          {avalesPorTipo.length > 0 ? (
-                            <div className="space-y-3">
-                              {avalesPorTipo.map((aval) => (
+                              <div>
+                                <h3 className="mb-3 text-sm font-semibold text-gray-900 dark:text-gray-100">Avales</h3>
+                                {avalesDeForma.length > 0 ? (
+                                  <div className="space-y-3">
+                                    {avalesDeForma.map((aval) => (
                                 <div
                                   key={aval.id}
                                   className="w-fit min-w-[360px] max-w-xl rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/30"
@@ -979,12 +1001,15 @@ export default function EventoDetailPage() {
                                 </div>
                               ))}
                             </div>
-                          ) : (
-                            <p className="text-sm text-gray-500 dark:text-gray-400">
-                              Todavía no se ha creado ningún aval para este tipo de participación.
-                            </p>
-                          )}
-                        </div>
+                                ) : (
+                                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                                    Todavía no se ha creado ningún aval para esta forma de participación.
+                                  </p>
+                                )}
+                              </div>
+                            </div>
+                          );
+                        })}
                       </div>
                     )}
                   </div>

--- a/app/(app)/eventos/_components/evento-form-helpers.ts
+++ b/app/(app)/eventos/_components/evento-form-helpers.ts
@@ -11,7 +11,6 @@ import {
   getCategoryByCatalogValue,
   normalizeCategoryValue,
 } from "@/lib/utils/categories";
-import { getCatalogItemCode } from "@/lib/utils/catalog";
 import { formatDateInput, getCalendarMonth } from "@/lib/utils/formatters/dates";
 import type { CatalogItem } from "@/types/catalog";
 import type { Evento, FormaParticipacionInputDto } from "@/types/evento";
@@ -38,7 +37,6 @@ export const EMPTY_FORM_VALUES: EventoFormValues = {
   numEntrenadoresMujeres: 0,
   numAtletasHombres: 0,
   numAtletasMujeres: 0,
-  eventoItems: [],
   formasParticipacion: [],
 };
 
@@ -67,33 +65,6 @@ export function resolveCategoriaCatalogItem(
 }
 
 export function mapEventoToFormValues(evento: Evento): EventoFormValues {
-  const eventoItemsFromFormas =
-    evento.formasParticipacion?.flatMap((forma) => {
-      const fuente = tipoAvalToFuente(forma.tipoAval);
-      if (!fuente) return [];
-
-      return (forma.items ?? []).map((item) => ({
-        itemId: item.item.id,
-        mes: item.mes,
-        presupuesto: Number.parseFloat(item.presupuesto) || 0,
-        fuente,
-        referencia: forma.referencia ?? "",
-        montoComprometido:
-          Number.parseFloat(item.montoComprometido ?? "0") || 0,
-        montoEjecutado: Number.parseFloat(item.montoEjecutado ?? "0") || 0,
-      }));
-    }) ?? [];
-
-  const fallbackEventoItems =
-    evento.eventoItems?.map((item) => ({
-      itemId: item.item.id,
-      mes: item.mes,
-      presupuesto: Number.parseFloat(item.presupuesto) || 0,
-      fuente: item.fuente ?? "FONDOS_PUBLICOS",
-      montoComprometido: Number.parseFloat(item.montoComprometido ?? "0") || 0,
-      montoEjecutado: Number.parseFloat(item.montoEjecutado ?? "0") || 0,
-    })) ?? [];
-
   return {
     codigo: evento.codigo ?? "",
     tipoParticipacion:
@@ -123,21 +94,32 @@ export function mapEventoToFormValues(evento: Evento): EventoFormValues {
     numEntrenadoresMujeres: evento.numEntrenadoresMujeres ?? 0,
     numAtletasHombres: evento.numAtletasHombres ?? 0,
     numAtletasMujeres: evento.numAtletasMujeres ?? 0,
-    eventoItems:
-      eventoItemsFromFormas.length > 0
-        ? eventoItemsFromFormas
-        : fallbackEventoItems,
     formasParticipacion:
-      evento.formasParticipacion?.map((forma) => ({
-        id: forma.id,
-        tipoAval: forma.tipoAval,
-        referencia: forma.referencia ?? "",
-        observacion: forma.observacion ?? "",
-        numEntrenadoresHombres: forma.numEntrenadoresHombres,
-        numEntrenadoresMujeres: forma.numEntrenadoresMujeres,
-        numAtletasHombres: forma.numAtletasHombres,
-        numAtletasMujeres: forma.numAtletasMujeres,
-      })) ?? [],
+      evento.formasParticipacion?.map((forma) => {
+        const fuente = tipoAvalToFuente(forma.tipoAval);
+        return {
+          id: forma.id,
+          tipoAval: forma.tipoAval,
+          referencia: forma.referencia ?? "",
+          observacion: forma.observacion ?? "",
+          numEntrenadoresHombres: forma.numEntrenadoresHombres,
+          numEntrenadoresMujeres: forma.numEntrenadoresMujeres,
+          numAtletasHombres: forma.numAtletasHombres,
+          numAtletasMujeres: forma.numAtletasMujeres,
+          items: fuente
+            ? (forma.items ?? []).map((item) => ({
+                itemId: item.item.id,
+                mes: item.mes,
+                presupuesto: Number.parseFloat(item.presupuesto) || 0,
+                fuente,
+                montoComprometido:
+                  Number.parseFloat(item.montoComprometido ?? "0") || 0,
+                montoEjecutado:
+                  Number.parseFloat(item.montoEjecutado ?? "0") || 0,
+              }))
+            : [],
+        };
+      }) ?? [],
   };
 }
 
@@ -151,41 +133,22 @@ function tipoAvalToFuente(
 
 function buildFormasParticipacionInput(
   values: EventoFormValues,
-  existingFormas?: Evento["formasParticipacion"],
 ): FormaParticipacionInputDto[] {
-  const eventoItems = values.eventoItems ?? [];
-  const existingFormaByKey = new Map(
-    (existingFormas ?? []).map((forma) => [
-      `${forma.tipoAval}::${forma.referencia?.trim() || ""}`,
-      forma,
-    ]),
-  );
-
   return (values.formasParticipacion ?? []).map((forma) => {
     const fuente = tipoAvalToFuente(forma.tipoAval);
-    const referencia = forma.referencia?.trim() || "";
     const items = fuente
-      ? eventoItems
-          .filter(
-            (item) =>
-              item.fuente === fuente &&
-              (item.referencia?.trim() || "") === referencia,
-          )
-          .map((item) => ({
-            itemId: item.itemId,
-            mes: item.mes,
-            presupuesto: item.presupuesto,
-          }))
+      ? (forma.items ?? []).map((item) => ({
+          itemId: item.itemId,
+          mes: item.mes,
+          presupuesto: item.presupuesto,
+        }))
       : [];
-    const existingForma = existingFormaByKey.get(
-      `${forma.tipoAval}::${referencia}`,
-    );
-    const resolvedId = forma.id ?? existingForma?.id;
+    const resolvedId = forma.id;
 
     return {
       ...(resolvedId ? { id: resolvedId } : {}),
       tipoAval: forma.tipoAval,
-      referencia: referencia || undefined,
+      referencia: forma.referencia?.trim() || undefined,
       observacion: forma.observacion?.trim() || undefined,
       numEntrenadoresHombres: forma.numEntrenadoresHombres,
       numEntrenadoresMujeres: forma.numEntrenadoresMujeres,
@@ -243,7 +206,6 @@ export function buildUpdateEventoPayloadFromForm(
   values: EventoFormValues,
   disciplinaId?: number,
   categoriaId?: number,
-  evento?: Evento,
 ): UpdateEventoPayload | null {
   const tipoParticipacion =
     normalizeEventoTipoParticipacion(values.tipoParticipacion) ?? undefined;
@@ -282,10 +244,7 @@ export function buildUpdateEventoPayloadFromForm(
       ? formatDateInput(values.fechaInicio)
       : null,
     fechaFin: values.fechaFin?.trim() ? formatDateInput(values.fechaFin) : null,
-    formasParticipacion: buildFormasParticipacionInput(
-      values,
-      evento?.formasParticipacion,
-    ),
+    formasParticipacion: buildFormasParticipacionInput(values),
   };
 }
 

--- a/app/(app)/eventos/_components/evento-form.tsx
+++ b/app/(app)/eventos/_components/evento-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Controller } from "react-hook-form";
-import { Plus, Sparkles, Trash2 } from "lucide-react";
+import { Plus, Sparkles } from "lucide-react";
 
 import DatePicker from "@/components/forms/DatePicker";
 import type { Evento } from "@/types/evento";
@@ -13,11 +13,10 @@ import {
   EVENTO_TAREA_OPTIONS,
   EVENTO_TIPO_PARTICIPACION_OPTIONS,
   TIPO_AVAL_OPTIONS,
-  getTipoAvalLabel,
 } from "@/lib/constants";
 import { getCatalogItemCode } from "@/lib/utils/catalog";
-import { parseDecimalInput, parseIntegerInput } from "./evento-form-helpers";
 import EventoFileUpload from "./evento-file-upload";
+import FormaParticipacionCard from "./forma-participacion-card";
 import { useEventoForm } from "./use-evento-form";
 
 type Props = {
@@ -25,30 +24,6 @@ type Props = {
   evento?: Evento;
   onCreated?: () => Promise<void>;
   onUpdated?: () => Promise<void>;
-};
-
-function tipoAvalToFuente(
-  tipoAval?: string,
-): "FONDOS_PUBLICOS" | "AUTOGESTION" | undefined {
-  return tipoAval === "FONDOS_PUBLICOS" || tipoAval === "AUTOGESTION"
-    ? tipoAval
-    : undefined;
-}
-
-const PRESUPUESTO_SECTION_INFO: Record<
-  "FONDOS_PUBLICOS" | "AUTOGESTION",
-  { title: string; description: string; empty: string }
-> = {
-  FONDOS_PUBLICOS: {
-    title: "Fondos públicos",
-    description: "Items financiados con presupuesto público.",
-    empty: "No hay items de fondos públicos.",
-  },
-  AUTOGESTION: {
-    title: "Fondos de autogestión",
-    description: "Items financiados con recursos de autogestión.",
-    empty: "No hay items de autogestión.",
-  },
 };
 
 export default function EventoForm({
@@ -59,7 +34,6 @@ export default function EventoForm({
 }: Props) {
   const {
     addFormaParticipacion,
-    appendBudgetItem,
     archivo,
     archivoPreview,
     buttonLabel,
@@ -69,12 +43,10 @@ export default function EventoForm({
     disciplinas,
     draggingArchivo,
     errors,
-    eventoItemsValues,
-    fields,
     formasParticipacionFields,
-    formasParticipacionValues,
     generateCodigoError,
     generatingCodigo,
+    getValues,
     handleArchivoDragLeave,
     handleArchivoDragOver,
     handleArchivoDrop,
@@ -85,12 +57,9 @@ export default function EventoForm({
     itemsByActividad,
     onSubmit,
     register,
-    remove,
     removeFormaParticipacion,
     removeFile,
     submitError,
-    totalPresupuestoAutogestion,
-    totalPresupuestoFondosPublicos,
     totalPresupuesto,
   } = useEventoForm({
     mode,
@@ -99,8 +68,7 @@ export default function EventoForm({
     onUpdated,
   });
 
-  const availableTipoAvalOptions = TIPO_AVAL_OPTIONS;
-  const canAddFormaParticipacion = availableTipoAvalOptions.length > 0;
+  const canAddFormaParticipacion = formasParticipacionFields.length < 3;
 
   return (
     <form
@@ -551,431 +519,22 @@ export default function EventoForm({
       </div>
 
       <div className="p-5 space-y-3">
-        {formasParticipacionFields.map((formaField, formaIndex) => {
-          const tipoAval =
-            formasParticipacionValues[formaIndex]?.tipoAval ??
-            formaField.tipoAval;
-          const fuente = tipoAvalToFuente(tipoAval);
-          const sectionInfo = fuente
-            ? PRESUPUESTO_SECTION_INFO[fuente]
-            : undefined;
-          const sectionTotal =
-            fuente === "FONDOS_PUBLICOS"
-              ? totalPresupuestoFondosPublicos
-              : fuente === "AUTOGESTION"
-                ? totalPresupuestoAutogestion
-                : 0;
-          const sectionItems = fuente
-            ? fields
-                .map((field, index) => ({
-                  field,
-                  index,
-                  itemFuente:
-                    eventoItemsValues[index]?.fuente ?? "FONDOS_PUBLICOS",
-                  itemReferencia:
-                    eventoItemsValues[index]?.referencia?.trim() || "",
-                }))
-                .filter(
-                  (item) =>
-                    item.itemFuente === fuente &&
-                    item.itemReferencia ===
-                      (formasParticipacionValues[formaIndex]?.referencia?.trim() ||
-                        ""),
-                )
-            : [];
-
-          return (
-            <div
-              key={formaField.id}
-              className="rounded-xl border border-gray-200 bg-gray-50/60 p-4 dark:border-gray-700/60 dark:bg-gray-900/20"
-            >
-              <input
-                type="hidden"
-                {...register(`formasParticipacion.${formaIndex}.tipoAval`)}
-                value={tipoAval}
-              />
-
-              <div className="mb-4 flex items-start justify-between gap-3">
-                <span className="inline-flex items-center rounded-full bg-violet-100 px-2.5 py-1 text-xs font-medium text-violet-700 dark:bg-violet-900/30 dark:text-violet-300">
-                  {getTipoAvalLabel(tipoAval)}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => removeFormaParticipacion(formaIndex)}
-                  className="rounded-lg p-2 text-red-500 transition-colors hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/20"
-                  title="Eliminar tipo de participación"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              </div>
-
-              <div className="mb-4 grid gap-4 md:grid-cols-2">
-                <div>
-                  <label className="block text-sm font-medium mb-1">
-                    Referencia <span className="text-red-600">*</span>
-                  </label>
-                  <input
-                    className="form-input w-full"
-                    type="text"
-                    placeholder="Referencia de la participación (ej: nombre de la organización, institución o similar)"
-                    required
-                    {...register(
-                      `formasParticipacion.${formaIndex}.referencia`,
-                    )}
-                  />
-                  {errors.formasParticipacion?.[formaIndex]?.referencia && (
-                    <p className="mt-1 text-xs text-red-600">
-                      {
-                        errors.formasParticipacion[formaIndex]?.referencia
-                          ?.message
-                      }
-                    </p>
-                  )}
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-1">
-                    Observación
-                  </label>
-                  <input
-                    className="form-input w-full"
-                    type="text"
-                    placeholder="Detalle opcional"
-                    {...register(
-                      `formasParticipacion.${formaIndex}.observacion`,
-                    )}
-                  />
-                  {errors.formasParticipacion?.[formaIndex]?.observacion && (
-                    <p className="mt-1 text-xs text-red-600">
-                      {
-                        errors.formasParticipacion[formaIndex]?.observacion
-                          ?.message
-                      }
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-                <div>
-                  <label className="block text-sm font-medium mb-1">
-                    Entrenadores y otro personal (hombres)
-                  </label>
-                  <input
-                    className="form-input w-full"
-                    type="text"
-                    inputMode="numeric"
-                    {...register(
-                      `formasParticipacion.${formaIndex}.numEntrenadoresHombres`,
-                      { setValueAs: parseIntegerInput },
-                    )}
-                  />
-                  <p className="mt-1 text-xs text-gray-500">
-                    Cupo compartido: entrenadores, jueces, delegados, etc.
-                  </p>
-                  {errors.formasParticipacion?.[formaIndex]
-                    ?.numEntrenadoresHombres && (
-                    <p className="mt-1 text-xs text-red-600">
-                      {
-                        errors.formasParticipacion[formaIndex]
-                          ?.numEntrenadoresHombres?.message
-                      }
-                    </p>
-                  )}
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-1">
-                    Entrenadores y otro personal (mujeres)
-                  </label>
-                  <input
-                    className="form-input w-full"
-                    type="text"
-                    inputMode="numeric"
-                    {...register(
-                      `formasParticipacion.${formaIndex}.numEntrenadoresMujeres`,
-                      { setValueAs: parseIntegerInput },
-                    )}
-                  />
-                  <p className="mt-1 text-xs text-gray-500">
-                    Cupo compartido: entrenadores, jueces, delegados, etc.
-                  </p>
-                  {errors.formasParticipacion?.[formaIndex]
-                    ?.numEntrenadoresMujeres && (
-                    <p className="mt-1 text-xs text-red-600">
-                      {
-                        errors.formasParticipacion[formaIndex]
-                          ?.numEntrenadoresMujeres?.message
-                      }
-                    </p>
-                  )}
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-1">
-                    Atletas hombres
-                  </label>
-                  <input
-                    className="form-input w-full"
-                    type="text"
-                    inputMode="numeric"
-                    {...register(
-                      `formasParticipacion.${formaIndex}.numAtletasHombres`,
-                      { setValueAs: parseIntegerInput },
-                    )}
-                  />
-                  {errors.formasParticipacion?.[formaIndex]
-                    ?.numAtletasHombres && (
-                    <p className="mt-1 text-xs text-red-600">
-                      {
-                        errors.formasParticipacion[formaIndex]
-                          ?.numAtletasHombres?.message
-                      }
-                    </p>
-                  )}
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-1">
-                    Atletas mujeres
-                  </label>
-                  <input
-                    className="form-input w-full"
-                    type="text"
-                    inputMode="numeric"
-                    {...register(
-                      `formasParticipacion.${formaIndex}.numAtletasMujeres`,
-                      { setValueAs: parseIntegerInput },
-                    )}
-                  />
-                  {errors.formasParticipacion?.[formaIndex]
-                    ?.numAtletasMujeres && (
-                    <p className="mt-1 text-xs text-red-600">
-                      {
-                        errors.formasParticipacion[formaIndex]
-                          ?.numAtletasMujeres?.message
-                      }
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              {fuente && sectionInfo && (
-                <div className="mt-4 space-y-3 border-t border-gray-200 pt-4 dark:border-gray-700/60">
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
-                      <h3 className="font-medium text-gray-800 dark:text-gray-100">
-                        {sectionInfo.title}
-                      </h3>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        {sectionInfo.description}
-                      </p>
-                    </div>
-                    <div className="text-right">
-                      <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                        Total
-                      </p>
-                      <p className="text-base font-semibold text-gray-800 dark:text-gray-100">
-                        $
-                        {sectionTotal.toLocaleString("es-EC", {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2,
-                        })}
-                      </p>
-                    </div>
-                  </div>
-
-                  {sectionItems.map(({ field, index }, sectionIndex) => (
-                    <div
-                      key={field.id}
-                      className="space-y-2 rounded-lg bg-white p-3 dark:bg-gray-800/70"
-                    >
-                      <input
-                        type="hidden"
-                        {...register(`eventoItems.${index}.fuente`)}
-                        value={fuente}
-                      />
-                      <input
-                        type="hidden"
-                        {...register(`eventoItems.${index}.referencia`)}
-                        value={
-                          formasParticipacionValues[formaIndex]?.referencia ?? ""
-                        }
-                      />
-
-                      <div className="grid grid-cols-12 gap-3 items-start">
-                        <div className="col-span-11">
-                          {sectionIndex === 0 && (
-                            <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
-                              Item
-                            </label>
-                          )}
-                          <select
-                            className="form-select w-full text-sm"
-                            {...register(`eventoItems.${index}.itemId`, {
-                              setValueAs: (v) =>
-                                v === "" ? undefined : Number(v),
-                            })}
-                          >
-                            <option value="">Seleccionar item...</option>
-                            {Object.entries(itemsByActividad).map(
-                              ([actName, items]) => (
-                                <optgroup key={actName} label={actName}>
-                                  {items.map((item) => (
-                                    <option key={item.id} value={item.id}>
-                                      {item.numero} - {item.nombre}
-                                    </option>
-                                  ))}
-                                </optgroup>
-                              ),
-                            )}
-                          </select>
-                          {errors.eventoItems?.[index]?.itemId && (
-                            <p className="mt-1 text-xs text-red-600">
-                              {errors.eventoItems[index].itemId?.message}
-                            </p>
-                          )}
-                        </div>
-
-                        <div className="col-span-1 flex items-end">
-                          {sectionIndex === 0 && (
-                            <span className="mb-1 block select-none text-xs text-transparent">
-                              .
-                            </span>
-                          )}
-                          <button
-                            type="button"
-                            onClick={() => remove(index)}
-                            className="rounded-lg p-2 text-red-500 transition-colors hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/20"
-                            title="Eliminar item"
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </button>
-                        </div>
-                      </div>
-
-                      <div className="grid grid-cols-1 gap-3 md:grid-cols-4 items-start">
-                        <div>
-                          {sectionIndex === 0 && (
-                            <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
-                              Mes
-                            </label>
-                          )}
-                          <select
-                            className="form-select w-full text-sm"
-                            {...register(`eventoItems.${index}.mes`, {
-                              setValueAs: (v) =>
-                                v === "" ? undefined : Number(v),
-                            })}
-                          >
-                            <option value="">Mes...</option>
-                            {EVENTO_MES_OPTIONS.map((m) => (
-                              <option key={m.value} value={m.value}>
-                                {m.label}
-                              </option>
-                            ))}
-                          </select>
-                          {errors.eventoItems?.[index]?.mes && (
-                            <p className="mt-1 text-xs text-red-600">
-                              {errors.eventoItems[index].mes?.message}
-                            </p>
-                          )}
-                        </div>
-
-                        <div>
-                          {sectionIndex === 0 && (
-                            <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
-                              Presupuesto ($)
-                            </label>
-                          )}
-                          <input
-                            className="form-input w-full text-sm"
-                            type="text"
-                            inputMode="decimal"
-                            placeholder="0.00"
-                            {...register(`eventoItems.${index}.presupuesto`, {
-                              setValueAs: parseDecimalInput,
-                            })}
-                          />
-                          {errors.eventoItems?.[index]?.presupuesto && (
-                            <p className="mt-1 text-xs text-red-600">
-                              {errors.eventoItems[index].presupuesto?.message}
-                            </p>
-                          )}
-                        </div>
-
-                        <div>
-                          {sectionIndex === 0 && (
-                            <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
-                              Comprometido ($)
-                            </label>
-                          )}
-                          <input
-                            className="form-input w-full text-sm"
-                            type="text"
-                            inputMode="decimal"
-                            placeholder="0.00"
-                            {...register(
-                              `eventoItems.${index}.montoComprometido`,
-                              {
-                                setValueAs: parseDecimalInput,
-                              },
-                            )}
-                          />
-                        </div>
-
-                        <div>
-                          {sectionIndex === 0 && (
-                            <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
-                              Ejecutado ($)
-                            </label>
-                          )}
-                          <input
-                            className="form-input w-full text-sm"
-                            type="text"
-                            inputMode="decimal"
-                            placeholder="0.00"
-                            {...register(
-                              `eventoItems.${index}.montoEjecutado`,
-                              {
-                                setValueAs: parseDecimalInput,
-                              },
-                            )}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-
-                  <button
-                    type="button"
-                    onClick={() =>
-                      appendBudgetItem(
-                        fuente,
-                        formasParticipacionValues[formaIndex]?.referencia?.trim() ||
-                          "",
-                      )
-                    }
-                    className="flex items-center gap-2 text-sm font-medium text-violet-600 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-300"
-                  >
-                    <Plus className="h-4 w-4" />
-                    Agregar item de {sectionInfo.title.toLowerCase()}
-                  </button>
-
-                  {sectionItems.length === 0 && (
-                    <p className="text-sm italic text-gray-400 dark:text-gray-500">
-                      {sectionInfo.empty}
-                    </p>
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        })}
+        {formasParticipacionFields.map((formaField, formaIndex) => (
+          <FormaParticipacionCard
+            key={formaField.id}
+            control={control}
+            register={register}
+            errors={errors}
+            getValues={getValues}
+            formaIndex={formaIndex}
+            itemsByActividad={itemsByActividad}
+            onRemove={() => removeFormaParticipacion(formaIndex)}
+          />
+        ))}
 
         {canAddFormaParticipacion && (
           <div className="flex flex-wrap gap-2">
-            {availableTipoAvalOptions.map((option) => (
+            {TIPO_AVAL_OPTIONS.map((option) => (
               <button
                 key={option.value}
                 type="button"

--- a/app/(app)/eventos/_components/forma-participacion-card.tsx
+++ b/app/(app)/eventos/_components/forma-participacion-card.tsx
@@ -1,0 +1,435 @@
+"use client";
+
+import {
+  useFieldArray,
+  useWatch,
+  type Control,
+  type FieldErrors,
+  type UseFormGetValues,
+  type UseFormRegister,
+} from "react-hook-form";
+import { Plus, Trash2 } from "lucide-react";
+
+import { EVENTO_MES_OPTIONS, getTipoAvalLabel } from "@/lib/constants";
+import type { CatalogItemPresupuestario } from "@/types/catalog";
+import type { EventoFormValues } from "@/lib/validation/evento";
+import { parseDecimalInput, parseIntegerInput } from "./evento-form-helpers";
+
+function tipoAvalToFuente(
+  tipoAval?: string,
+): "FONDOS_PUBLICOS" | "AUTOGESTION" | undefined {
+  return tipoAval === "FONDOS_PUBLICOS" || tipoAval === "AUTOGESTION"
+    ? tipoAval
+    : undefined;
+}
+
+const PRESUPUESTO_SECTION_INFO: Record<
+  "FONDOS_PUBLICOS" | "AUTOGESTION",
+  { title: string; description: string; empty: string }
+> = {
+  FONDOS_PUBLICOS: {
+    title: "Fondos públicos",
+    description: "Items financiados con presupuesto público.",
+    empty: "No hay items de fondos públicos.",
+  },
+  AUTOGESTION: {
+    title: "Fondos de autogestión",
+    description: "Items financiados con recursos de autogestión.",
+    empty: "No hay items de autogestión.",
+  },
+};
+
+type Props = {
+  control: Control<EventoFormValues>;
+  register: UseFormRegister<EventoFormValues>;
+  errors: FieldErrors<EventoFormValues>;
+  getValues: UseFormGetValues<EventoFormValues>;
+  formaIndex: number;
+  itemsByActividad: Record<string, CatalogItemPresupuestario[]>;
+  onRemove: () => void;
+};
+
+export default function FormaParticipacionCard({
+  control,
+  register,
+  errors,
+  getValues,
+  formaIndex,
+  itemsByActividad,
+  onRemove,
+}: Props) {
+  const tipoAval = useWatch({
+    control,
+    name: `formasParticipacion.${formaIndex}.tipoAval`,
+  });
+  const fuente = tipoAvalToFuente(tipoAval);
+  const sectionInfo = fuente ? PRESUPUESTO_SECTION_INFO[fuente] : undefined;
+
+  const {
+    fields: itemFields,
+    append: appendItem,
+    remove: removeItem,
+  } = useFieldArray({
+    control,
+    name: `formasParticipacion.${formaIndex}.items`,
+  });
+
+  const itemsValues =
+    useWatch({ control, name: `formasParticipacion.${formaIndex}.items` }) ?? [];
+
+  const sectionTotal = itemsValues.reduce(
+    (sum, item) => sum + (item?.presupuesto || 0),
+    0,
+  );
+
+  const formaErrors = errors.formasParticipacion?.[formaIndex];
+
+  const handleAddItem = () => {
+    if (!fuente) return;
+    appendItem({
+      itemId: 0,
+      mes: getValues("mesProgramado") || 1,
+      presupuesto: 0,
+      fuente,
+      montoComprometido: 0,
+      montoEjecutado: 0,
+    });
+  };
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-gray-50/60 p-4 dark:border-gray-700/60 dark:bg-gray-900/20">
+      <input
+        type="hidden"
+        {...register(`formasParticipacion.${formaIndex}.tipoAval`)}
+      />
+
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <span className="inline-flex items-center rounded-full bg-violet-100 px-2.5 py-1 text-xs font-medium text-violet-700 dark:bg-violet-900/30 dark:text-violet-300">
+          {getTipoAvalLabel(tipoAval)}
+        </span>
+        <button
+          type="button"
+          onClick={onRemove}
+          className="rounded-lg p-2 text-red-500 transition-colors hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/20"
+          title="Eliminar tipo de participación"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="mb-4 grid gap-4 md:grid-cols-2">
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Referencia <span className="text-red-600">*</span>
+          </label>
+          <input
+            className="form-input w-full"
+            type="text"
+            placeholder="Referencia de la participación (ej: nombre de la organización, institución o similar)"
+            required
+            {...register(`formasParticipacion.${formaIndex}.referencia`)}
+          />
+          {formaErrors?.referencia && (
+            <p className="mt-1 text-xs text-red-600">
+              {formaErrors.referencia.message}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Observación</label>
+          <input
+            className="form-input w-full"
+            type="text"
+            placeholder="Detalle opcional"
+            {...register(`formasParticipacion.${formaIndex}.observacion`)}
+          />
+          {formaErrors?.observacion && (
+            <p className="mt-1 text-xs text-red-600">
+              {formaErrors.observacion.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Entrenadores y otro personal (hombres)
+          </label>
+          <input
+            className="form-input w-full"
+            type="text"
+            inputMode="numeric"
+            {...register(
+              `formasParticipacion.${formaIndex}.numEntrenadoresHombres`,
+              { setValueAs: parseIntegerInput },
+            )}
+          />
+          <p className="mt-1 text-xs text-gray-500">
+            Cupo compartido: entrenadores, jueces, delegados, etc.
+          </p>
+          {formaErrors?.numEntrenadoresHombres && (
+            <p className="mt-1 text-xs text-red-600">
+              {formaErrors.numEntrenadoresHombres.message}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Entrenadores y otro personal (mujeres)
+          </label>
+          <input
+            className="form-input w-full"
+            type="text"
+            inputMode="numeric"
+            {...register(
+              `formasParticipacion.${formaIndex}.numEntrenadoresMujeres`,
+              { setValueAs: parseIntegerInput },
+            )}
+          />
+          <p className="mt-1 text-xs text-gray-500">
+            Cupo compartido: entrenadores, jueces, delegados, etc.
+          </p>
+          {formaErrors?.numEntrenadoresMujeres && (
+            <p className="mt-1 text-xs text-red-600">
+              {formaErrors.numEntrenadoresMujeres.message}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Atletas hombres
+          </label>
+          <input
+            className="form-input w-full"
+            type="text"
+            inputMode="numeric"
+            {...register(`formasParticipacion.${formaIndex}.numAtletasHombres`, {
+              setValueAs: parseIntegerInput,
+            })}
+          />
+          {formaErrors?.numAtletasHombres && (
+            <p className="mt-1 text-xs text-red-600">
+              {formaErrors.numAtletasHombres.message}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Atletas mujeres
+          </label>
+          <input
+            className="form-input w-full"
+            type="text"
+            inputMode="numeric"
+            {...register(`formasParticipacion.${formaIndex}.numAtletasMujeres`, {
+              setValueAs: parseIntegerInput,
+            })}
+          />
+          {formaErrors?.numAtletasMujeres && (
+            <p className="mt-1 text-xs text-red-600">
+              {formaErrors.numAtletasMujeres.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {fuente && sectionInfo && (
+        <div className="mt-4 space-y-3 border-t border-gray-200 pt-4 dark:border-gray-700/60">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h3 className="font-medium text-gray-800 dark:text-gray-100">
+                {sectionInfo.title}
+              </h3>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {sectionInfo.description}
+              </p>
+            </div>
+            <div className="text-right">
+              <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Total
+              </p>
+              <p className="text-base font-semibold text-gray-800 dark:text-gray-100">
+                $
+                {sectionTotal.toLocaleString("es-EC", {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </p>
+            </div>
+          </div>
+
+          {itemFields.map((field, index) => (
+            <div
+              key={field.id}
+              className="space-y-2 rounded-lg bg-white p-3 dark:bg-gray-800/70"
+            >
+              <input
+                type="hidden"
+                {...register(
+                  `formasParticipacion.${formaIndex}.items.${index}.fuente`,
+                )}
+              />
+
+              <div className="grid grid-cols-12 gap-3 items-start">
+                <div className="col-span-11">
+                  {index === 0 && (
+                    <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+                      Item
+                    </label>
+                  )}
+                  <select
+                    className="form-select w-full text-sm"
+                    {...register(
+                      `formasParticipacion.${formaIndex}.items.${index}.itemId`,
+                      { setValueAs: (v) => (v === "" ? undefined : Number(v)) },
+                    )}
+                  >
+                    <option value="">Seleccionar item...</option>
+                    {Object.entries(itemsByActividad).map(([actName, items]) => (
+                      <optgroup key={actName} label={actName}>
+                        {items.map((item) => (
+                          <option key={item.id} value={item.id}>
+                            {item.numero} - {item.nombre}
+                          </option>
+                        ))}
+                      </optgroup>
+                    ))}
+                  </select>
+                  {formaErrors?.items?.[index]?.itemId && (
+                    <p className="mt-1 text-xs text-red-600">
+                      {formaErrors.items[index]?.itemId?.message}
+                    </p>
+                  )}
+                </div>
+
+                <div className="col-span-1 flex items-end">
+                  {index === 0 && (
+                    <span className="mb-1 block select-none text-xs text-transparent">
+                      .
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => removeItem(index)}
+                    className="rounded-lg p-2 text-red-500 transition-colors hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/20"
+                    title="Eliminar item"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-4 items-start">
+                <div>
+                  {index === 0 && (
+                    <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+                      Mes
+                    </label>
+                  )}
+                  <select
+                    className="form-select w-full text-sm"
+                    {...register(
+                      `formasParticipacion.${formaIndex}.items.${index}.mes`,
+                      { setValueAs: (v) => (v === "" ? undefined : Number(v)) },
+                    )}
+                  >
+                    <option value="">Mes...</option>
+                    {EVENTO_MES_OPTIONS.map((m) => (
+                      <option key={m.value} value={m.value}>
+                        {m.label}
+                      </option>
+                    ))}
+                  </select>
+                  {formaErrors?.items?.[index]?.mes && (
+                    <p className="mt-1 text-xs text-red-600">
+                      {formaErrors.items[index]?.mes?.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  {index === 0 && (
+                    <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+                      Presupuesto ($)
+                    </label>
+                  )}
+                  <input
+                    className="form-input w-full text-sm"
+                    type="text"
+                    inputMode="decimal"
+                    placeholder="0.00"
+                    {...register(
+                      `formasParticipacion.${formaIndex}.items.${index}.presupuesto`,
+                      { setValueAs: parseDecimalInput },
+                    )}
+                  />
+                  {formaErrors?.items?.[index]?.presupuesto && (
+                    <p className="mt-1 text-xs text-red-600">
+                      {formaErrors.items[index]?.presupuesto?.message}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  {index === 0 && (
+                    <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+                      Comprometido ($)
+                    </label>
+                  )}
+                  <input
+                    className="form-input w-full text-sm"
+                    type="text"
+                    inputMode="decimal"
+                    placeholder="0.00"
+                    {...register(
+                      `formasParticipacion.${formaIndex}.items.${index}.montoComprometido`,
+                      { setValueAs: parseDecimalInput },
+                    )}
+                  />
+                </div>
+
+                <div>
+                  {index === 0 && (
+                    <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+                      Ejecutado ($)
+                    </label>
+                  )}
+                  <input
+                    className="form-input w-full text-sm"
+                    type="text"
+                    inputMode="decimal"
+                    placeholder="0.00"
+                    {...register(
+                      `formasParticipacion.${formaIndex}.items.${index}.montoEjecutado`,
+                      { setValueAs: parseDecimalInput },
+                    )}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            onClick={handleAddItem}
+            className="flex items-center gap-2 text-sm font-medium text-violet-600 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-300"
+          >
+            <Plus className="h-4 w-4" />
+            Agregar item de {sectionInfo.title.toLowerCase()}
+          </button>
+
+          {itemFields.length === 0 && (
+            <p className="text-sm italic text-gray-400 dark:text-gray-500">
+              {sectionInfo.empty}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/eventos/_components/use-evento-form.ts
+++ b/app/(app)/eventos/_components/use-evento-form.ts
@@ -114,56 +114,36 @@ export function useEventoForm({
     }
   }, [getValues, setValue]);
 
-  const { fields, append, remove } = useFieldArray({
-    control,
-    name: "eventoItems",
-  });
-
-  // Totales: useWatch (no watch()) para reflejar de forma fiable los valores del
-  // field array tras el reset() en edición. Con watch() el total quedaba en 0
-  // aunque los inputs de cada item sí mostraran su presupuesto (desync RHF).
-  const eventoItemsValues = useWatch({ control, name: "eventoItems" }) ?? [];
-
-  const totalPresupuesto = useMemo(
-    () =>
-      eventoItemsValues.reduce(
-        (sum, item) => sum + (item?.presupuesto || 0),
-        0,
-      ),
-    [eventoItemsValues],
-  );
-
-  const totalPresupuestoFondosPublicos = useMemo(
-    () =>
-      eventoItemsValues.reduce(
-        (sum, item) =>
-          sum + (item?.fuente === "FONDOS_PUBLICOS" ? item?.presupuesto || 0 : 0),
-        0,
-      ),
-    [eventoItemsValues],
-  );
-
-  const totalPresupuestoAutogestion = useMemo(
-    () =>
-      eventoItemsValues.reduce(
-        (sum, item) =>
-          sum + (item?.fuente === "AUTOGESTION" ? item?.presupuesto || 0 : 0),
-        0,
-      ),
-    [eventoItemsValues],
-  );
-
   const {
     fields: formasParticipacionFields,
     append: appendFormaParticipacion,
-    remove: removeFormaParticipacionField,
+    remove: removeFormaParticipacion,
   } = useFieldArray({
     control,
     name: "formasParticipacion",
   });
 
-  const formasParticipacionValues =
-    useWatch({ control, name: "formasParticipacion" }) ?? [];
+  // Totales: useWatch (no watch()) para reflejar de forma fiable los valores del
+  // field array tras el reset() en edición. Con watch() el total quedaba en 0
+  // aunque los inputs de cada item sí mostraran su presupuesto (desync RHF).
+  const formasParticipacionValues = useWatch({
+    control,
+    name: "formasParticipacion",
+  });
+
+  const totalPresupuesto = useMemo(
+    () =>
+      (formasParticipacionValues ?? []).reduce(
+        (sum, forma) =>
+          sum +
+          (forma?.items ?? []).reduce(
+            (acc, item) => acc + (item?.presupuesto || 0),
+            0,
+          ),
+        0,
+      ),
+    [formasParticipacionValues],
+  );
 
   const addFormaParticipacion = useCallback(
     (tipoAval: "FONDOS_PUBLICOS" | "AUTOGESTION" | "SOLO_RESULTADO") => {
@@ -175,44 +155,10 @@ export function useEventoForm({
         numEntrenadoresMujeres: 0,
         numAtletasHombres: 0,
         numAtletasMujeres: 0,
+        items: [],
       });
     },
     [appendFormaParticipacion],
-  );
-
-  const removeFormaParticipacion = useCallback(
-    (formaIndex: number) => {
-      const forma = formasParticipacionValues[formaIndex];
-      const fuente =
-        forma?.tipoAval === "FONDOS_PUBLICOS" || forma?.tipoAval === "AUTOGESTION"
-          ? forma.tipoAval
-          : null;
-      const referencia = forma?.referencia?.trim() || "";
-
-      if (fuente) {
-        const itemIndexes = eventoItemsValues
-          .map((item, index) => ({
-            index,
-            sameFuente: item?.fuente === fuente,
-            sameReferencia: (item?.referencia?.trim() || "") === referencia,
-          }))
-          .filter((item) => item.sameFuente && item.sameReferencia)
-          .map((item) => item.index)
-          .sort((a, b) => b - a);
-
-        if (itemIndexes.length > 0) {
-          remove(itemIndexes);
-        }
-      }
-
-      removeFormaParticipacionField(formaIndex);
-    },
-    [
-      eventoItemsValues,
-      formasParticipacionValues,
-      remove,
-      removeFormaParticipacionField,
-    ],
   );
 
   useEffect(() => {
@@ -351,7 +297,6 @@ export function useEventoForm({
             values,
             disciplina?.id,
             categoria?.id,
-            evento,
           );
           if (!updatePayload) {
             setSubmitError("Completa los campos obligatorios del evento.");
@@ -440,30 +385,10 @@ export function useEventoForm({
       ? "Guardar cambios"
       : "Guardar evento";
 
-  const appendBudgetItem = useCallback(
-    (
-      fuente: "FONDOS_PUBLICOS" | "AUTOGESTION",
-      referencia: string,
-    ) => {
-      append({
-        itemId: 0,
-        mes: getValues("mesProgramado") || 1,
-        presupuesto: 0,
-        fuente,
-        referencia,
-        montoComprometido: 0,
-        montoEjecutado: 0,
-      });
-    },
-    [append, getValues],
-  );
-
   return {
     archivo,
     archivoPreview,
     addFormaParticipacion,
-    append,
-    appendBudgetItem,
     buttonLabel,
     catalogError,
     catalogLoading,
@@ -472,9 +397,7 @@ export function useEventoForm({
     disciplinas,
     draggingArchivo,
     errors,
-    fields,
     formasParticipacionFields,
-    formasParticipacionValues,
     generateCodigoError,
     generatingCodigo,
     handleArchivoDragLeave,
@@ -487,14 +410,11 @@ export function useEventoForm({
     itemsByActividad,
     mode,
     onSubmit,
-    eventoItemsValues,
     register,
-    remove,
     removeFormaParticipacion,
     removeFile,
     submitError,
-    totalPresupuestoAutogestion,
-    totalPresupuestoFondosPublicos,
+    getValues,
     totalPresupuesto,
   };
 }

--- a/lib/validation/evento.ts
+++ b/lib/validation/evento.ts
@@ -14,7 +14,6 @@ export const eventoItemSchema = z.object({
   fuente: z.enum(["FONDOS_PUBLICOS", "AUTOGESTION"], {
     error: () => ({ message: "Selecciona una fuente" }),
   }),
-  referencia: z.string().optional(),
   montoComprometido: z.number().min(0).optional(),
   montoEjecutado: z.number().min(0).optional(),
 });
@@ -31,6 +30,7 @@ export const formaParticipacionSchema = z.object({
   numEntrenadoresMujeres: z.number().int().min(0),
   numAtletasHombres: z.number().int().min(0),
   numAtletasMujeres: z.number().int().min(0),
+  items: z.array(eventoItemSchema).optional(),
 });
 
 const optionalDateSchema = z.string().optional().or(z.literal(""));
@@ -98,8 +98,10 @@ export const eventoSchema = z.object({
     .min(0, "Numero de entrenadores mujeres invalido"),
   numAtletasHombres: z.number().int().min(0, "Numero de atletas hombres invalido"),
   numAtletasMujeres: z.number().int().min(0, "Numero de atletas mujeres invalido"),
-  eventoItems: z.array(eventoItemSchema).optional(),
-  formasParticipacion: z.array(formaParticipacionSchema).optional(),
+  formasParticipacion: z
+    .array(formaParticipacionSchema)
+    .max(3, "Máximo 3 tipos de participación")
+    .optional(),
 }).superRefine((values, ctx) => {
   const hasInicio = Boolean(values.fechaInicio && values.fechaInicio.trim());
   const hasFin = Boolean(values.fechaFin && values.fechaFin.trim());
@@ -116,18 +118,6 @@ export const eventoSchema = z.object({
       code: z.ZodIssueCode.custom,
       path: ["fechaFin"],
       message,
-    });
-  }
-
-  const claves = (values.formasParticipacion ?? []).map(
-    (f) => `${f.tipoAval}::${f.referencia.trim().toUpperCase()}`,
-  );
-  if (new Set(claves).size !== claves.length) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ["formasParticipacion"],
-      message:
-        "No puede repetirse la misma combinación de tipo de aval y referencia.",
     });
   }
 });


### PR DESCRIPTION
Antes los items se linkeaban a su forma solo por `fuente` (o por match de texto tipoAval+referencia, parche previo). Con dos formas del mismo tipoAval los items se mezclaban o se perdian en el formulario, y al guardar se duplicaban en ambas formas.

Ahora cada forma tiene su propio array `items` anidado (ya soportado por el DTO del backend), ligado por forma.id en vez de texto. Reemplaza el mecanismo de referencia-string del commit anterior.

Ademas, en el detalle del evento: cada forma de participacion se muestra en su propia tarjeta (separacion visual clara) y los avales se listan debajo de la forma a la que pertenecen (antes se agrupaban por tipo, mezclando avales de formas distintas).