### PR TITLE
refactor(catalogos): consumir roles/categorias dinámicas desde la API

### DIFF
--- a/app/(app)/carga-masiva/_components/row-validation.ts
+++ b/app/(app)/carga-masiva/_components/row-validation.ts
@@ -1,6 +1,5 @@
-import { ROLES } from "@/lib/constants";
-import { APP_CATEGORIES, isValidAppCategory, normalizeCategoryValue } from "@/lib/utils/categories";
 import type { CatalogItem } from "@/types/catalog";
+import type { Role } from "@/types/role";
 import type { ColumnDef, UploadType } from "./template-columns";
 
 export type RowIssues = Record<string, string>;
@@ -26,7 +25,19 @@ const disciplineAliases: Record<string, string> = {
   KARATEDO: "KARATE_DO",
 };
 
-const roleValues = new Set(ROLES.map((role) => normalizeComparable(role)));
+/** Set con códigos y nombres (normalizados) de un catálogo, para validar contra ambos. */
+function buildCatalogValueSet(
+  items: Array<Pick<CatalogItem, "codigo" | "nombre">>
+) {
+  const set = new Set<string>();
+  for (const item of items) {
+    const code = normalizeComparable(item.codigo ?? "");
+    const name = normalizeComparable(item.nombre ?? "");
+    if (code) set.add(code);
+    if (name) set.add(name);
+  }
+  return set;
+}
 
 const roleAliases: Record<string, string> = {
   ADMINISTRADOR_GENERAL: "ADMIN",
@@ -58,10 +69,10 @@ function splitDisciplinaCandidates(value: string) {
     .filter(Boolean);
 }
 
-function isValidRole(value: string) {
+function isValidRole(value: string, roleValues: Set<string>) {
   const normalized = normalizeComparable(value);
   const resolved = roleAliases[normalized] ?? normalized;
-  return roleValues.has(resolved);
+  return roleValues.has(resolved) || roleValues.has(normalized);
 }
 
 function isValidDiscipline(value: string, disciplines: CatalogItem[]) {
@@ -92,18 +103,23 @@ function isValidDiscipline(value: string, disciplines: CatalogItem[]) {
   });
 }
 
-function isValidCategory(value: string) {
-  return isValidAppCategory(value);
+function isValidCategory(value: string, categoriaValues: Set<string>) {
+  const normalized = normalizeComparable(value);
+  if (!normalized) return false;
+  if (normalized === "TODAS") return true;
+  return categoriaValues.has(normalized);
 }
 
-function getInvalidCategories(value: string) {
-  const normalized = normalizeCategoryValue(value);
+function getInvalidCategories(value: string, categoriaValues: Set<string>) {
+  const normalized = normalizeComparable(value);
   if (!normalized || normalized === "TODAS") return [];
 
   const candidates = splitDisciplinaCandidates(value);
   if (candidates.length === 0) return [value.trim()].filter(Boolean);
 
-  return candidates.filter((candidate) => !isValidCategory(candidate));
+  return candidates.filter(
+    (candidate) => !isValidCategory(candidate, categoriaValues)
+  );
 }
 
 function getInvalidDisciplines(value: string, disciplines: CatalogItem[]) {
@@ -278,9 +294,13 @@ export function validatePreviewRows(
   type: UploadType,
   rows: Record<string, string>[],
   columns: ColumnDef[],
-  disciplines: CatalogItem[]
+  disciplines: CatalogItem[],
+  categorias: CatalogItem[] = [],
+  roles: Array<Pick<Role, "codigo" | "nombre">> = []
 ): RowIssuesByIndex {
   const issuesByRow: RowIssuesByIndex = {};
+  const categoriaValues = buildCatalogValueSet(categorias);
+  const roleValues = buildCatalogValueSet(roles);
 
   rows.forEach((row, rowIndex) => {
     const issues: RowIssues = {};
@@ -294,16 +314,24 @@ export function validatePreviewRows(
 
     if (type === "usuarios") {
       const categoria = row.CATEGORIA?.trim() ?? "";
-      if (categoria && !isValidCategory(categoria)) {
-        const invalidCategories = getInvalidCategories(categoria);
+      if (
+        categoria &&
+        categorias.length > 0 &&
+        !isValidCategory(categoria, categoriaValues)
+      ) {
+        const invalidCategories = getInvalidCategories(categoria, categoriaValues);
         const detail =
           invalidCategories.length > 0
             ? invalidCategories.map((item) => `"${item}"`).join(", ")
             : `"${categoria}"`;
+        const validList = categorias
+          .map((item) => item.nombre)
+          .filter(Boolean)
+          .join(", ");
         pushIssue(
           issues,
           "CATEGORIA",
-          `Categoría inválida: ${detail}. Valores válidos: ${APP_CATEGORIES.join(", ")}`,
+          `Categoría inválida: ${detail}. Valores válidos: ${validList}`,
         );
       }
 
@@ -313,7 +341,7 @@ export function validatePreviewRows(
       }
 
       const cargo = row.CARGO?.trim() ?? "";
-      if (cargo && !isValidRole(cargo)) {
+      if (cargo && roles.length > 0 && !isValidRole(cargo, roleValues)) {
         pushIssue(issues, "CARGO", "Cargo no encontrado en el sistema");
       }
 

--- a/app/(app)/carga-masiva/page.tsx
+++ b/app/(app)/carga-masiva/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import * as XLSX from "xlsx";
 import {
   Users,
@@ -20,9 +20,9 @@ import {
 } from "@/lib/api/user";
 import { uploadEventsExcel, type UploadExcelResponse } from "@/lib/api/eventos";
 import { getCatalog } from "@/lib/api/catalog";
-import { ROLES } from "@/lib/constants";
-import { APP_CATEGORIES } from "@/lib/utils/categories";
-import { formatRole } from "@/lib/utils/formatters/text";
+import { listRoles } from "@/lib/api/roles";
+import type { CatalogItem } from "@/types/catalog";
+import type { Role } from "@/types/role";
 import FileDropzone from "./_components/file-dropzone";
 import DataPreviewTable from "./_components/data-preview-table";
 import UploadResults from "./_components/upload-results";
@@ -55,9 +55,11 @@ export default function CargaMasivaPage() {
   const [checking, setChecking] = useState(false);
   const [existingCedulas, setExistingCedulas] =
     useState<CheckCedulasResponse | null>(null);
-  const [disciplinasCatalog, setDisciplinasCatalog] = useState<
-    { id: number; nombre: string; codigo?: string | null }[]
-  >([]);
+  const [disciplinasCatalog, setDisciplinasCatalog] = useState<CatalogItem[]>(
+    []
+  );
+  const [categoriasCatalog, setCategoriasCatalog] = useState<CatalogItem[]>([]);
+  const [rolesCatalog, setRolesCatalog] = useState<Role[]>([]);
   const [catalogLoading, setCatalogLoading] = useState(false);
   const [response, setResponse] = useState<
     UploadUsersExcelResponse | UploadExcelResponse | null
@@ -74,18 +76,30 @@ export default function CargaMasivaPage() {
       : baseColumns;
 
   const ensureCatalogLoaded = useCallback(async () => {
-    if (disciplinasCatalog.length > 0) return disciplinasCatalog;
-    if (catalogLoading) return disciplinasCatalog;
+    if (disciplinasCatalog.length > 0 || catalogLoading) {
+      return {
+        disciplinas: disciplinasCatalog,
+        categorias: categoriasCatalog,
+        roles: rolesCatalog,
+      };
+    }
 
     setCatalogLoading(true);
     try {
-      const result = await getCatalog();
-      const disciplinas = result.data?.disciplinas ?? [];
+      const [catalogRes, rolesRes] = await Promise.all([
+        getCatalog(),
+        listRoles().catch(() => null),
+      ]);
+      const disciplinas = catalogRes.data?.disciplinas ?? [];
+      const categorias = catalogRes.data?.categorias ?? [];
+      const roles = rolesRes?.data ?? [];
       if (disciplinas.length === 0) {
         throw new Error("No se encontraron disciplinas en el catálogo.");
       }
       setDisciplinasCatalog(disciplinas);
-      return disciplinas;
+      setCategoriasCatalog(categorias);
+      setRolesCatalog(roles);
+      return { disciplinas, categorias, roles };
     } catch (error) {
       throw error instanceof Error
         ? error
@@ -93,7 +107,14 @@ export default function CargaMasivaPage() {
     } finally {
       setCatalogLoading(false);
     }
-  }, [catalogLoading, disciplinasCatalog]);
+  }, [catalogLoading, disciplinasCatalog, categoriasCatalog, rolesCatalog]);
+
+  // Precargar catálogos al entrar al flujo de usuarios para poblar los hints.
+  useEffect(() => {
+    if (uploadType === "usuarios") {
+      void ensureCatalogLoaded().catch(() => {});
+    }
+  }, [uploadType, ensureCatalogLoaded]);
 
   const findEventSheetName = useCallback((workbook: XLSX.WorkBook) => {
     const normalize = (value: string) => value.trim().toUpperCase();
@@ -320,12 +341,14 @@ export default function CargaMasivaPage() {
             rows.push(mapped);
           }
 
-          const disciplinas = await ensureCatalogLoaded();
+          const { disciplinas, categorias, roles } = await ensureCatalogLoaded();
           const issues = validatePreviewRows(
             uploadType!,
             rows,
             uploadType === "eventos" ? allColumns : currentBaseColumns,
-            disciplinas
+            disciplinas,
+            categorias,
+            roles
           );
 
           setParsedRows(rows);
@@ -617,20 +640,38 @@ export default function CargaMasivaPage() {
                     CATEGORIA es opcional. Si la dejas vacía, se usará TODAS.
                   </p>
                   <p>
-                    Categorías válidas: {APP_CATEGORIES.join(", ")}.
+                    Categorías válidas:{" "}
+                    {categoriasCatalog.length > 0
+                      ? categoriasCatalog
+                          .map((c) => c.nombre)
+                          .filter(Boolean)
+                          .join(", ")
+                      : "las registradas en el catálogo"}
+                    .
                   </p>
                   <p>
                     Campos opcionales: {USERS_OPTIONAL_COLUMNS.join(", ")}.
                   </p>
                   <p>
                     Roles aceptados:{" "}
-                    {ROLES.map((role) => `${role} (${formatRole(role)})`).join(", ")}.
+                    {rolesCatalog.length > 0
+                      ? rolesCatalog
+                          .map((role) => role.nombre)
+                          .filter(Boolean)
+                          .join(", ")
+                      : "los roles válidos del sistema"}
+                    .
                   </p>
                 </div>
               )}
 
               <div className="mt-4">
-                <UploadInstructions type={uploadType} />
+                <UploadInstructions
+                  type={uploadType}
+                  categorias={categoriasCatalog
+                    .map((c) => c.nombre)
+                    .filter(Boolean)}
+                />
               </div>
             </div>
           </div>

--- a/app/(app)/deportistas/_components/deportista-form.tsx
+++ b/app/(app)/deportistas/_components/deportista-form.tsx
@@ -20,10 +20,6 @@ import {
   getCatalogItemCode,
   resolveCatalogItemCodeFromList,
 } from "@/lib/utils/catalog";
-import {
-  getCategoryCodeValue,
-  getCategoryOptions,
-} from "@/lib/utils/categories";
 
 const EMPTY_FORM_VALUES: DeportistaFormValues = {
   nombres: "",
@@ -47,12 +43,10 @@ const mapDeportistaToFormValues = (
   genero: (deportista.genero ?? undefined) as DeportistaFormValues["genero"],
   fechaNacimiento: deportista.fechaNacimiento ?? "",
   categoriaCodigo:
-    getCategoryCodeValue(
-      deportista.categoriaCodigo ??
-        deportista.categoria?.codigo ??
-        deportista.categoria?.nombre ??
-        (deportista.categoriaId ? String(deportista.categoriaId) : "")
-    ),
+    deportista.categoriaCodigo ??
+    deportista.categoria?.codigo ??
+    deportista.categoria?.nombre ??
+    (deportista.categoriaId ? String(deportista.categoriaId) : ""),
   disciplinaCodigo:
     deportista.disciplinaCodigo ??
     deportista.disciplina?.codigo ??
@@ -76,6 +70,7 @@ export default function DeportistaForm({
   onUpdated,
 }: Props) {
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [categorias, setCategorias] = useState<CatalogItem[]>([]);
   const [disciplinas, setDisciplinas] = useState<CatalogItem[]>([]);
   const [catalogLoading, setCatalogLoading] = useState(true);
   const [catalogError, setCatalogError] = useState<string | null>(null);
@@ -107,13 +102,16 @@ export default function DeportistaForm({
     }
     reset({
       ...initialValues,
-      categoriaCodigo: getCategoryCodeValue(initialValues.categoriaCodigo),
+      categoriaCodigo: resolveCatalogItemCodeFromList(
+        categorias,
+        initialValues.categoriaCodigo
+      ),
       disciplinaCodigo: resolveCatalogItemCodeFromList(
         disciplinas,
         initialValues.disciplinaCodigo
       ),
     });
-  }, [deportista, initialValues, mode, catalogLoading, reset, disciplinas]);
+  }, [deportista, initialValues, mode, catalogLoading, reset, disciplinas, categorias]);
 
   const afiliacion = watch("afiliacion", false);
   const afiliacionInicio = watch("afiliacionInicio");
@@ -142,12 +140,13 @@ export default function DeportistaForm({
         setCatalogLoading(true);
         setCatalogError(null);
         const res = await getCatalog();
-        const discs = res.data?.disciplinas ?? [];
-        setDisciplinas(discs);
+        setCategorias(res.data?.categorias ?? []);
+        setDisciplinas(res.data?.disciplinas ?? []);
       } catch (err: any) {
         setCatalogError(
           err?.message ?? "No se pudieron cargar categorias/disciplinas."
         );
+        setCategorias([]);
         setDisciplinas([]);
       } finally {
         setCatalogLoading(false);
@@ -360,14 +359,15 @@ export default function DeportistaForm({
           <select
             id="categoriaCodigo"
             className="form-select w-full"
+            disabled={catalogLoading || !categorias.length}
             {...register("categoriaCodigo", {
               setValueAs: (v) => String(v),
             })}
           >
             <option value="">Selecciona una opcion</option>
-            {getCategoryOptions().map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
+            {categorias.map((c) => (
+              <option key={c.id} value={getCatalogItemCode(c)}>
+                {c.nombre}
               </option>
             ))}
           </select>

--- a/app/(app)/usuarios/_components/usuario-form.tsx
+++ b/app/(app)/usuarios/_components/usuario-form.tsx
@@ -21,9 +21,11 @@ import {
   type UserFormValues,
 } from "@/lib/validation/user";
 import { CatalogItem } from "@/types/catalog";
+import type { Role as RoleCatalog } from "@/types/role";
 import type { Role, User } from "@/types/user";
 import { formatRole } from "@/lib/utils/formatters";
 import { normalizeRoleCode } from "@/lib/auth/roles";
+import { useRoles } from "@/lib/hooks/use-catalog";
 import {
   getCatalogItemId,
   resolveCatalogItemIdFromList,
@@ -33,25 +35,15 @@ import {
   getCategoryIdOptions,
 } from "@/lib/utils/categories";
 
-const ROLE_OPTIONS: Role[] = [
-  "ADMIN",
-  "SECRETARIA",
-  "SECRETARIA_DTM",
-  "DTM",
-  "METODOLOGO",
-  "ENTRENADOR",
-  "USUARIO",
-  "DEPORTISTA",
-  "PDA",
-  "CONTROL_PREVIO",
-  "FINANCIERO",
-  "COMPRAS_PUBLICAS",
-  "LECTOR",
-];
-
 const defaultRoleSelection: Role[] = [];
 
-const formatRoleLabel = (role: Role) => formatRole(role);
+/** Nombre configurado del rol desde el catálogo; cae al código formateado. */
+function roleLabelFromCatalog(role: Role, roles: RoleCatalog[]) {
+  const match = roles.find(
+    (r) => normalizeRoleCode(r.codigo) === normalizeRoleCode(role),
+  );
+  return match?.nombre?.trim() || formatRole(role);
+}
 
 const MAX_SELECTED_DISCIPLINAS = 3;
 const MAX_SELECTED_ROLES = 3;
@@ -80,13 +72,18 @@ function buildDisciplinasLabel(
   }`;
 }
 
-function buildRolesLabel(selected: Role[], maxSelectedLabels = MAX_SELECTED_ROLES) {
+function buildRolesLabel(
+  selected: Role[],
+  roles: RoleCatalog[],
+  maxSelectedLabels = MAX_SELECTED_ROLES,
+) {
   if (!selected || selected.length === 0) return "Selecciona roles";
-  if (selected.length <= maxSelectedLabels) {
-    return selected.map((r) => formatRoleLabel(r)).join(", ");
+  const labels = selected.map((r) => roleLabelFromCatalog(r, roles));
+  if (labels.length <= maxSelectedLabels) {
+    return labels.join(", ");
   }
-  return `${selected.slice(0, maxSelectedLabels).map((r) => formatRoleLabel(r)).join(", ")} +${
-    selected.length - maxSelectedLabels
+  return `${labels.slice(0, maxSelectedLabels).join(", ")} +${
+    labels.length - maxSelectedLabels
   }`;
 }
 
@@ -164,6 +161,7 @@ export default function UsuarioForm({
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [disciplinasOpen, setDisciplinasOpen] = useState(false);
   const [rolesOpen, setRolesOpen] = useState(false);
+  const { roles: rolesCatalog, isLoading: rolesLoading } = useRoles();
 
   const schema = useMemo(
     () => (mode === "edit" ? updateUserSchema : createUserSchema),
@@ -506,7 +504,7 @@ export default function UsuarioForm({
                     className="form-select flex w-full items-center justify-between px-3 py-2 text-left"
                   >
                     <span className="truncate text-sm">
-                      {buildRolesLabel((field.value ?? []) as Role[])}
+                      {buildRolesLabel((field.value ?? []) as Role[], rolesCatalog)}
                     </span>
                     <span className="flex items-center gap-2 shrink-0">
                       <ChevronDown className="h-4 w-4 text-gray-400" />
@@ -536,16 +534,28 @@ export default function UsuarioForm({
                   </div>
 
                   <div className="max-h-64 overflow-y-auto py-1">
-                    {ROLE_OPTIONS.map((role) => {
+                    {rolesLoading && rolesCatalog.length === 0 ? (
+                      <p className="px-3 py-2.5 text-sm text-gray-500 dark:text-gray-400">
+                        Cargando roles...
+                      </p>
+                    ) : null}
+                    {rolesCatalog.map((roleItem) => {
+                      const role = roleItem.codigo as Role;
                       const selected = (field.value ?? []) as Role[];
-                      const isChecked = selected.includes(role);
+                      const isChecked = selected.some(
+                        (r) => normalizeRoleCode(r) === normalizeRoleCode(role),
+                      );
                       return (
                         <button
-                          key={role}
+                          key={roleItem.id}
                           type="button"
                           onClick={() => {
                             const next = isChecked
-                              ? selected.filter((r) => r !== role)
+                              ? selected.filter(
+                                  (r) =>
+                                    normalizeRoleCode(r) !==
+                                    normalizeRoleCode(role),
+                                )
                               : [...selected, role];
                             field.onChange(next);
                           }}
@@ -567,7 +577,9 @@ export default function UsuarioForm({
                           >
                             <Check className="h-3.5 w-3.5" />
                           </span>
-                          <span className="truncate">{formatRoleLabel(role)}</span>
+                          <span className="truncate">
+                            {roleLabelFromCatalog(role, rolesCatalog)}
+                          </span>
                         </button>
                       );
                     })}

--- a/app/(app)/usuarios/page.tsx
+++ b/app/(app)/usuarios/page.tsx
@@ -12,30 +12,35 @@ import UsuarioTable from "./_components/usuario-table";
 import UploadUsersExcelModal from "@/components/users/upload-excel-users-modal";
 import { softDeleteUser, listUsers } from "@/lib/api/user";
 import type { User } from "@/types/user";
-import { CONFIRM_CLEANUP_DELAY, DEFAULT_PAGE_SIZE, ROLES } from "@/lib/constants";
+import { CONFIRM_CLEANUP_DELAY, DEFAULT_PAGE_SIZE } from "@/lib/constants";
 import { useResourceList } from "@/lib/hooks/use-resource-list";
 import { useUrlFilters } from "@/lib/hooks/use-url-filters";
 import { useStatusToast } from "@/lib/hooks/use-status-toast";
+import { useRoles } from "@/lib/hooks/use-catalog";
 import { canonicalizeRoleCode } from "@/lib/auth/roles";
-import { formatRole } from "@/lib/utils/formatters";
 
 const MIN_QUERY_LENGTH = 2;
-const ROLE_OPTIONS = ROLES.map((role) => {
-  const canonicalRole = canonicalizeRoleCode(role);
-  return {
-    value: canonicalRole,
-    label: formatRole(canonicalRole),
-  };
-}).filter(
-  (option, index, array) =>
-    array.findIndex((item) => item.value === option.value) === index
-);
 
 export default function Usuarios() {
   const { filters, page, setFilter, setPage } = useUrlFilters("/usuarios", {
     query: "",
     role: "",
   });
+
+  const { roles: rolesCatalog } = useRoles();
+  const roleOptions = useMemo(
+    () =>
+      rolesCatalog
+        .map((role) => ({
+          value: canonicalizeRoleCode(role.codigo),
+          label: role.nombre,
+        }))
+        .filter(
+          (option, index, array) =>
+            array.findIndex((item) => item.value === option.value) === index
+        ),
+    [rolesCatalog]
+  );
 
   const normalizedQuery = useMemo(() => filters.query.trim(), [filters.query]);
   const selectedRole = useMemo(
@@ -160,7 +165,7 @@ export default function Usuarios() {
                 aria-label="Filtrar por roles"
               >
                 <option value="">Todos los roles</option>
-                {ROLE_OPTIONS.map((option) => (
+                {roleOptions.map((option) => (
                   <option key={option.value} value={option.value}>
                     {option.label}
                   </option>

--- a/components/ui/upload-instructions.tsx
+++ b/components/ui/upload-instructions.tsx
@@ -1,22 +1,30 @@
 "use client";
 
 import { Info } from "lucide-react";
-import { APP_CATEGORIES } from "@/lib/utils/categories";
 
 type UploadInstructionsProps = {
   type: "usuarios" | "eventos";
   compact?: boolean;
+  /** Nombres de categorías traídos del catálogo, para el hint de CATEGORIA. */
+  categorias?: string[];
 };
 
-const USERS_INSTRUCTIONS = [
-  "Usa la plantilla y no cambies los nombres de las columnas.",
-  "Formato: .xlsx (recomendado) o .csv.",
-  "CEDULA debe tener 10 dígitos.",
-  `CATEGORIA permite solo: ${APP_CATEGORIES.join(", ")}.`,
-  "DISCIPLINA debe existir en el catálogo (código o nombre exacto).",
-  "CARGO debe ser un rol válido del sistema.",
-  "Si una CEDULA ya existe, se actualiza; si no existe, se crea.",
-];
+function buildUsersInstructions(categorias?: string[]) {
+  const categoriaLine =
+    categorias && categorias.length > 0
+      ? `CATEGORIA permite solo: ${categorias.join(", ")}.`
+      : "CATEGORIA debe existir en el catálogo del sistema.";
+
+  return [
+    "Usa la plantilla y no cambies los nombres de las columnas.",
+    "Formato: .xlsx (recomendado) o .csv.",
+    "CEDULA debe tener 10 dígitos.",
+    categoriaLine,
+    "DISCIPLINA debe existir en el catálogo (código o nombre exacto).",
+    "CARGO debe ser un rol válido del sistema.",
+    "Si una CEDULA ya existe, se actualiza; si no existe, se crea.",
+  ];
+}
 
 const EVENTS_INSTRUCTIONS = [
   "Usa la plantilla y no cambies los nombres de las columnas.",
@@ -31,8 +39,12 @@ const EVENTS_INSTRUCTIONS = [
 export default function UploadInstructions({
   type,
   compact = false,
+  categorias,
 }: UploadInstructionsProps) {
-  const items = type === "usuarios" ? USERS_INSTRUCTIONS : EVENTS_INSTRUCTIONS;
+  const items =
+    type === "usuarios"
+      ? buildUsersInstructions(categorias)
+      : EVENTS_INSTRUCTIONS;
 
   return (
     <div

--- a/components/users/upload-excel-users-modal.tsx
+++ b/components/users/upload-excel-users-modal.tsx
@@ -3,8 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { X, Upload, FileSpreadsheet, Loader2, CheckCircle, AlertTriangle } from "lucide-react";
 import { uploadUsersExcel, type UploadUsersExcelResponse } from "@/lib/api/user";
-import { ROLES } from "@/lib/constants";
-import { formatRole } from "@/lib/utils/formatters/text";
+import { useCatalog, useRoles } from "@/lib/hooks/use-catalog";
 import UploadInstructions from "@/components/ui/upload-instructions";
 
 type UploadUsersExcelModalProps = {
@@ -24,6 +23,8 @@ export default function UploadUsersExcelModal({
   const [error, setError] = useState<string | null>(null);
   const [dragging, setDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { roles } = useRoles();
+  const { categorias } = useCatalog();
 
   useEffect(() => {
     if (isOpen) {
@@ -160,7 +161,10 @@ export default function UploadUsersExcelModal({
                     </p>
                     <p className="text-xs text-gray-500 mt-2 max-w-md">
                       Solo se aceptan disciplinas registradas en el catalogo; puedes enviar el codigo o el nombre exacto. Para CARGO se aceptan los roles validos del sistema:{" "}
-                      {ROLES.map((role) => `${role} (${formatRole(role)})`).join(", ")}.
+                      {roles.length > 0
+                        ? roles.map((role) => role.nombre).filter(Boolean).join(", ")
+                        : "los roles del sistema"}
+                      .
                     </p>
                   </div>
                 )}
@@ -168,7 +172,11 @@ export default function UploadUsersExcelModal({
             )}
 
             {!response && (
-              <UploadInstructions type="usuarios" compact />
+              <UploadInstructions
+                type="usuarios"
+                compact
+                categorias={categorias.map((c) => c.nombre).filter(Boolean)}
+              />
             )}
 
             {error && (

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -30,25 +30,6 @@ export const TOAST_DURATION = 4000;
 /** Delay para limpiar item de confirmación después de cerrar modal */
 export const CONFIRM_CLEANUP_DELAY = 180;
 
-/** Roles disponibles en el sistema */
-export const ROLES = [
-  "admin",
-  "administrador",
-  "secretaria",
-  "dtm",
-  "metodologo",
-  "entrenador",
-  "usuario",
-  "deportista",
-  "pda",
-  "control_previo",
-  "compras_publicas",
-  "financiero",
-  "lector",
-] as const;
-
-export type Role = (typeof ROLES)[number];
-
 /** Opciones de género para formularios */
 export const GENERO_OPTIONS = [
   { value: "masculino", label: "Masculino" },

--- a/lib/hooks/use-catalog.ts
+++ b/lib/hooks/use-catalog.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getCatalog } from "@/lib/api/catalog";
+import { listRoles } from "@/lib/api/roles";
+import type { CatalogItem } from "@/types/catalog";
+import type { Role } from "@/types/role";
+
+/** Los catálogos cambian con muy poca frecuencia: cache más largo que el default. */
+const CATALOG_STALE_TIME = 5 * 60_000;
+
+/**
+ * Catálogos de categorías y disciplinas traídos del backend (`/catalog`).
+ * Cacheado y compartido por react-query (queryKey `["catalog"]`).
+ */
+export function useCatalog() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["catalog"],
+    queryFn: () => getCatalog(),
+    staleTime: CATALOG_STALE_TIME,
+  });
+
+  return {
+    categorias: (data?.data?.categorias ?? []) as CatalogItem[],
+    disciplinas: (data?.data?.disciplinas ?? []) as CatalogItem[],
+    isLoading,
+    error,
+  };
+}
+
+/**
+ * Catálogo de roles del sistema (`/roles`), con `id`, `codigo` y `nombre`.
+ * Comparte queryKey `["roles"]` con la administración de roles, así que
+ * renombrar un rol se refleja en todos los selects tras invalidar.
+ */
+export function useRoles() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["roles"],
+    queryFn: () => listRoles(),
+    staleTime: CATALOG_STALE_TIME,
+  });
+
+  return {
+    roles: (data?.data ?? []) as Role[],
+    isLoading,
+    error,
+  };
+}

--- a/lib/utils/categories.ts
+++ b/lib/utils/categories.ts
@@ -2,18 +2,12 @@ import type { CatalogItem } from "@/types/catalog";
 import {
   EVENTO_CATEGORIA_ALIASES,
   EVENTO_CATEGORIA_LABELS,
-  EVENTO_CATEGORIA_OPTIONS,
   EVENTO_CATEGORIA_VALUES,
 } from "@/lib/domain/evento-options";
 
 export const APP_CATEGORIES = EVENTO_CATEGORIA_VALUES;
 
 export type AppCategory = (typeof APP_CATEGORIES)[number];
-
-export type CategoryOption = {
-  value: AppCategory;
-  label: string;
-};
 
 export function normalizeCategoryValue(value?: string | null) {
   return (value ?? "")
@@ -53,17 +47,6 @@ export function formatCategoryLabel(value?: string | null, fallback = "-") {
   return categoryLabels.get(canonical) ?? canonical;
 }
 
-export function getCategoryOptions(): CategoryOption[] {
-  return EVENTO_CATEGORIA_OPTIONS.map((option) => ({
-    value: option.value,
-    label: option.label,
-  }));
-}
-
-export function getCategoryCodeValue(value?: string | null) {
-  return getCanonicalCategory(value) ?? "";
-}
-
 export function getCategoryByCatalogValue(
   items: CatalogItem[],
   value?: string | number | null
@@ -87,16 +70,14 @@ export function getCategoryByCatalogValue(
 }
 
 export function getCategoryIdOptions(items: CatalogItem[]): CatalogItem[] {
-  return APP_CATEGORIES.reduce<CatalogItem[]>((acc, category) => {
-    const item = getCategoryByCatalogValue(items, category);
-    if (!item) return acc;
-    acc.push({
-      id: item.id,
-      codigo: item.codigo,
-      nombre: formatCategoryLabel(category, category),
-    });
-    return acc;
-  }, []);
+  // Se incluyen TODAS las categorías del catálogo (no solo las conocidas), para
+  // que una categoría nueva creada en el backend aparezca en los selects sin
+  // tocar código. El `nombre` ya viene normalizado desde `getCatalog`.
+  return items.map((item) => ({
+    id: item.id,
+    codigo: item.codigo,
+    nombre: formatCategoryLabel(item.nombre, item.nombre),
+  }));
 }
 
 export function normalizeCategoryCatalogItems<T extends Pick<CatalogItem, "nombre">>(

--- a/lib/validation/deportista.ts
+++ b/lib/validation/deportista.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { APP_CATEGORIES } from "@/lib/utils/categories";
 
 export const deportistaSchema = z.object({
   nombres: z.string().min(2, "Nombres: minimo 2 caracteres").max(120),
@@ -11,12 +10,7 @@ export const deportistaSchema = z.object({
       message: "Selecciona genero",
     }),
   fechaNacimiento: z.string().min(1, "Fecha de nacimiento requerida"),
-  categoriaCodigo: z
-    .enum(APP_CATEGORIES)
-    .or(z.literal(""))
-    .refine((value) => value !== "", {
-      message: "Selecciona una categoria válida",
-    }),
+  categoriaCodigo: z.string().min(1, "Selecciona una categoria válida"),
   disciplinaCodigo: z.string().min(1, "Selecciona una disciplina"),
   afiliacion: z.boolean(),
   afiliacionInicio: z.string().optional().or(z.literal("")),

--- a/lib/validation/evento.ts
+++ b/lib/validation/evento.ts
@@ -1,6 +1,5 @@
 import {
   EVENTO_ALCANCE_VALUES,
-  EVENTO_CATEGORIA_VALUES,
   EVENTO_TIPO_EVENTO_VALUES,
   EVENTO_TIPO_PARTICIPACION_VALUES,
   type EventoTipoParticipacion
@@ -68,11 +67,7 @@ export const eventoSchema = z.object({
     .enum(["MASCULINO", "FEMENINO", "MASCULINO_FEMENINO"])
     .or(z.literal("")),
   disciplinaCodigo: z.string().min(1, "Selecciona una disciplina"),
-  categoriaCodigo: z
-    .enum(
-      [...EVENTO_CATEGORIA_VALUES] as [string, ...string[]]
-    )
-    .or(z.literal("")),
+  categoriaCodigo: z.string().max(100).or(z.literal("")),
   mesProgramado: z
     .number()
     .int()


### PR DESCRIPTION
Elimina listas hardcodeadas de roles y categorías; los selects, filtros y validaciones de carga masiva ahora se alimentan del catálogo del backend (nombre visible, código/id enviado).

- hooks react-query useCatalog() + useRoles() en lib/hooks/use-catalog.ts
- usuario-form: multi-select de roles desde /roles
- usuarios/page: filtro de roles dinámico
- deportista-form: select de categoría desde /catalog/categorias
- carga-masiva: validación de roles/categorías y textos de ayuda dinámicos
- enums zod de categoriaCodigo (deportista + evento) relajados a string
- elimina ROLES const de lib/constants; getCategoryIdOptions incluye todas las categorías del catálogo