### PR TITLE
fix(reformas): corregir build roto en evento-cambios-card

### DIFF
--- a/app/(fullscreen)/reformas/nueva/_components/evento-cambios-card.tsx
+++ b/app/(fullscreen)/reformas/nueva/_components/evento-cambios-card.tsx
@@ -232,7 +232,7 @@ function buildInitialBudgetRowsState(
 
   const restoredRows = originalRows.map((row) => {
     const itemId = row.itemId;
-    const key = typeof itemId === "number" ? `${itemId}-${row.mes}` : null;
+    const key = typeof itemId === "number" ? (`${itemId}-${row.mes}` as const) : null;
     let changedItem = key ? changedItemsByKey.get(key) : undefined;
 
     if (!changedItem && typeof itemId === "number") {
@@ -261,18 +261,18 @@ function buildInitialBudgetRowsState(
 
   const newRows = Array.from(changedItemsByItemId.values())
     .flat()
-    .map((item) => {
+    .map((item): BudgetRow => {
       const catalogItem = itemsCatalogo.find((option) => option.id === item.itemId);
       return {
         localId: `restored-new-${item.itemId}-${item.mes}`,
         itemId: item.itemId,
         itemNumero: catalogItem?.numero ?? "",
-      mes: item.mes,
-      presupuesto: String(item.presupuesto),
-      status: "new" as const,
-      montoMinimo: 0,
-    };
-  });
+        mes: item.mes,
+        presupuesto: String(item.presupuesto),
+        status: "new",
+        montoMinimo: 0,
+      };
+    });
 
   return [...restoredRows, ...newRows];
 }


### PR DESCRIPTION
## Summary
- El squash merge de #54 perdio el fix de tipos en `evento-cambios-card.tsx`, dejando main con build roto (2 errores TS).
- Reaplica el fix puntual: `as const` en el template literal de la key (matchea el tipo de `Map<`${number}-${number}`, ...>`), y tipo de retorno explicito `BudgetRow` en el `.map()` de `newRows` para que `itemNumero` no se ensanche de `number | ""` a `string | number`.
- Sin relacion con el feature de responsable del anticipo (ya en main, sin tocar).

## Test plan
- [x] `npm run build` corre limpio sobre main + este fix.