### PR TITLE
feat(catalogos): configurar la plantilla de pronostico por disciplina

### DIFF
--- a/app/(app)/avales/nuevo/page.tsx
+++ b/app/(app)/avales/nuevo/page.tsx
@@ -10,6 +10,7 @@ import AvalUploadOptions from "@/components/ui/aval-upload-options";
 import UploadModal from "@/components/ui/upload-modal";
 import { getAvalesByEvento, uploadConvocatoria } from "@/lib/api/avales";
 import { listEventos, type ListEventosOptions } from "@/lib/api/eventos";
+import { useDisciplinaPronosticoPlantilla } from "@/lib/hooks/use-catalog";
 import {
   getEventoFormasParticipacion,
   isEventoIncompleto,
@@ -82,6 +83,8 @@ export default function NuevoAvalPage() {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [uploadModalOpen, setUploadModalOpen] = useState(false);
   const [selectedEvento, setSelectedEvento] = useState<Evento | null>(null);
+  const { sinPlantilla: disciplinaSinPlantilla } =
+    useDisciplinaPronosticoPlantilla(selectedEvento?.disciplinaId);
 
   const userRoles = getNormalizedRoles(user);
   const isEntrenador = userRoles.includes("ENTRENADOR") && !isAdminUser(user);
@@ -258,8 +261,14 @@ export default function NuevoAvalPage() {
         avalesSelectedEvento,
       ).filter((forma) => forma.tipoAval === tipoAval)
     : [];
-  const submitDisabled =
+  const faltaFormaParticipacion =
     formasDelTipoSeleccionado.length > 0 && formaParticipacionId == null;
+  // Sin plantilla de pronóstico el backend rechaza la creación del aval, así
+  // que se corta antes de que el entrenador suba los documentos.
+  const submitDisabled = faltaFormaParticipacion || disciplinaSinPlantilla;
+  const submitDisabledReason = disciplinaSinPlantilla
+    ? `La disciplina ${selectedEvento?.disciplina?.nombre ?? "del evento"} no tiene una plantilla de pronóstico configurada. Pídele a un administrador que la configure antes de crear el aval.`
+    : "Selecciona una forma de participación para continuar.";
 
   return (
     <>
@@ -285,7 +294,7 @@ export default function NuevoAvalPage() {
         }.`}
         requirePronosticoDeportistas={false}
         submitDisabled={submitDisabled}
-        submitDisabledReason="Selecciona una forma de participación para continuar."
+        submitDisabledReason={submitDisabledReason}
       >
         <AvalUploadOptions
           evento={selectedEvento}

--- a/app/(app)/catalogos/_components/catalog-crud-view.tsx
+++ b/app/(app)/catalogos/_components/catalog-crud-view.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Pencil, Plus, Trash2 } from "lucide-react";
+import { AlertTriangle, Pencil, Plus, Trash2 } from "lucide-react";
 
 import AlertBanner from "@/components/ui/alert-banner";
 import ConfirmModal from "@/components/ui/confirm-modal";
@@ -11,6 +11,8 @@ import type { CatalogItem } from "@/types/catalog";
 type CatalogPayload = {
   nombre: string;
   codigo?: string | null;
+  /** Valor del select opcional; solo viaja si el catalogo define `selectField`. */
+  selectValue?: number | null;
 };
 
 type Notice = {
@@ -18,6 +20,24 @@ type Notice = {
   message: string;
   description?: string;
 } | null;
+
+/**
+ * Campo select opcional para catalogos que ademas de nombre y codigo tienen
+ * una relacion configurable (hoy: la plantilla de pronostico por disciplina).
+ */
+type SelectFieldConfig = {
+  label: string;
+  /** Texto de la opcion vacia, cuando no hay nada asignado. */
+  emptyLabel: string;
+  options: { value: number; label: string }[];
+  helpText?: string;
+  /** Valor actual del item, para precargar el formulario al editar. */
+  valueOf: (item: CatalogItem) => number | null;
+  /** Etiqueta a mostrar en la tarjeta cuando el item tiene valor. */
+  labelOf: (item: CatalogItem) => string | null;
+  /** Aviso en la tarjeta cuando el item no tiene valor asignado. */
+  missingLabel: string;
+};
 
 type Props = {
   title: string;
@@ -32,6 +52,7 @@ type Props = {
   onDelete: (id: number) => Promise<void>;
   singularTitle: string;
   backHref?: string;
+  selectField?: SelectFieldConfig;
 };
 
 export default function CatalogCrudView({
@@ -47,11 +68,13 @@ export default function CatalogCrudView({
   onDelete,
   singularTitle,
   backHref = "/catalogos",
+  selectField,
 }: Props) {
   const [formOpen, setFormOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<CatalogItem | null>(null);
   const [nombre, setNombre] = useState("");
   const [codigo, setCodigo] = useState("");
+  const [selectValue, setSelectValue] = useState<number | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -70,6 +93,7 @@ export default function CatalogCrudView({
     setEditingItem(null);
     setNombre("");
     setCodigo("");
+    setSelectValue(null);
     setFormError(null);
     setFormOpen(false);
   };
@@ -78,6 +102,7 @@ export default function CatalogCrudView({
     setEditingItem(null);
     setNombre("");
     setCodigo("");
+    setSelectValue(null);
     setFormError(null);
     setFormOpen(true);
   };
@@ -86,6 +111,7 @@ export default function CatalogCrudView({
     setEditingItem(item);
     setNombre(item.nombre ?? "");
     setCodigo(item.codigo ?? "");
+    setSelectValue(selectField ? selectField.valueOf(item) : null);
     setFormError(null);
     setFormOpen(true);
   };
@@ -103,9 +129,10 @@ export default function CatalogCrudView({
       setSaving(true);
       setFormError(null);
 
-      const payload = {
+      const payload: CatalogPayload = {
         nombre: cleanNombre,
         codigo: cleanCodigo || null,
+        ...(selectField ? { selectValue } : {}),
       };
 
       if (editingItem) {
@@ -246,6 +273,32 @@ export default function CatalogCrudView({
                 placeholder="Codigo"
               />
             </div>
+            {selectField && (
+              <div className="md:col-span-2">
+                <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-200">
+                  {selectField.label}
+                </label>
+                <select
+                  value={selectValue ?? ""}
+                  onChange={(e) =>
+                    setSelectValue(e.target.value ? Number(e.target.value) : null)
+                  }
+                  className="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-violet-500 focus:outline-none"
+                >
+                  <option value="">{selectField.emptyLabel}</option>
+                  {selectField.options.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                {selectField.helpText && (
+                  <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                    {selectField.helpText}
+                  </p>
+                )}
+              </div>
+            )}
           </div>
 
           {formError && (
@@ -333,6 +386,17 @@ export default function CatalogCrudView({
                       {item.eventosCount === 1 ? "" : "s"}
                     </p>
                   )}
+                  {selectField &&
+                    (selectField.labelOf(item) ? (
+                      <p className="mt-3 inline-flex items-center rounded-md bg-gray-100 dark:bg-gray-700/60 px-2 py-1 text-xs text-gray-600 dark:text-gray-300">
+                        {selectField.labelOf(item)}
+                      </p>
+                    ) : (
+                      <p className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-amber-50 dark:bg-amber-900/30 px-2 py-1 text-xs font-medium text-amber-700 dark:text-amber-300">
+                        <AlertTriangle className="w-3.5 h-3.5" />
+                        {selectField.missingLabel}
+                      </p>
+                    ))}
                 </div>
 
                 <div className="flex items-center gap-2 shrink-0 pt-1">

--- a/app/(app)/catalogos/disciplinas/page.tsx
+++ b/app/(app)/catalogos/disciplinas/page.tsx
@@ -7,12 +7,14 @@ import {
   createDisciplina,
   deleteDisciplina,
   getDisciplinas,
+  getPronosticoPlantillas,
   updateDisciplina,
 } from "@/lib/api/disciplinas";
-import type { CatalogItem } from "@/types/catalog";
+import type { CatalogItem, PronosticoPlantilla } from "@/types/catalog";
 
 export default function DisciplinasPage() {
   const [items, setItems] = useState<CatalogItem[]>([]);
+  const [plantillas, setPlantillas] = useState<PronosticoPlantilla[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -29,9 +31,20 @@ export default function DisciplinasPage() {
     }
   }, []);
 
+  // Las plantillas cambian muy poco: se cargan una vez para llenar el select.
+  const fetchPlantillas = useCallback(async () => {
+    try {
+      const res = await getPronosticoPlantillas();
+      setPlantillas(res.data ?? []);
+    } catch {
+      setPlantillas([]);
+    }
+  }, []);
+
   useEffect(() => {
     void fetchDisciplinas();
-  }, [fetchDisciplinas]);
+    void fetchPlantillas();
+  }, [fetchDisciplinas, fetchPlantillas]);
 
   return (
     <CatalogCrudView
@@ -43,15 +56,36 @@ export default function DisciplinasPage() {
       emptyMessage="No hay disciplinas registradas."
       onReload={fetchDisciplinas}
       onCreate={async (payload) => {
-        await createDisciplina(payload);
+        await createDisciplina({
+          nombre: payload.nombre,
+          codigo: payload.codigo,
+          pronosticoPlantillaId: payload.selectValue ?? null,
+        });
       }}
       onUpdate={async (id, payload) => {
-        await updateDisciplina(id, payload);
+        await updateDisciplina(id, {
+          nombre: payload.nombre,
+          codigo: payload.codigo,
+          pronosticoPlantillaId: payload.selectValue ?? null,
+        });
       }}
       onDelete={async (id) => {
         await deleteDisciplina(id);
       }}
       singularTitle="Disciplina"
+      selectField={{
+        label: "Plantilla de pronostico",
+        emptyLabel: "Sin plantilla asignada",
+        helpText:
+          "Define el formato del excel de pronostico. Sin plantilla no se pueden crear avales de esta disciplina.",
+        options: plantillas.map((plantilla) => ({
+          value: plantilla.id,
+          label: plantilla.nombre,
+        })),
+        valueOf: (item) => item.pronosticoPlantilla?.id ?? null,
+        labelOf: (item) => item.pronosticoPlantilla?.nombre ?? null,
+        missingLabel: "Sin plantilla de pronostico",
+      }}
     />
   );
 }

--- a/app/(app)/catalogos/disciplinas/page.tsx
+++ b/app/(app)/catalogos/disciplinas/page.tsx
@@ -25,7 +25,11 @@ export default function DisciplinasPage() {
       const res = await getDisciplinas();
       setItems(res.data ?? []);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "No se pudieron cargar las disciplinas.");
+      setError(
+        err instanceof Error
+          ? err.message
+          : "No se pudieron cargar las disciplinas.",
+      );
     } finally {
       setLoading(false);
     }
@@ -73,19 +77,25 @@ export default function DisciplinasPage() {
         await deleteDisciplina(id);
       }}
       singularTitle="Disciplina"
-      selectField={{
-        label: "Plantilla de pronostico",
-        emptyLabel: "Sin plantilla asignada",
-        helpText:
-          "Define el formato del excel de pronostico. Sin plantilla no se pueden crear avales de esta disciplina.",
-        options: plantillas.map((plantilla) => ({
-          value: plantilla.id,
-          label: plantilla.nombre,
-        })),
-        valueOf: (item) => item.pronosticoPlantilla?.id ?? null,
-        labelOf: (item) => item.pronosticoPlantilla?.nombre ?? null,
-        missingLabel: "Sin plantilla de pronostico",
-      }}
+      // Si el backend todavia no expone las plantillas, la pantalla queda
+      // igual que antes en vez de marcar todo como "sin plantilla".
+      selectField={
+        plantillas.length === 0
+          ? undefined
+          : {
+              label: "Plantilla de pronostico",
+              emptyLabel: "Sin plantilla asignada",
+              helpText:
+                "Define el formato del excel de pronostico. Sin plantilla no se pueden crear avales de esta disciplina.",
+              options: plantillas.map((plantilla) => ({
+                value: plantilla.id,
+                label: plantilla.nombre,
+              })),
+              valueOf: (item) => item.pronosticoPlantilla?.id ?? null,
+              labelOf: (item) => item.pronosticoPlantilla?.nombre ?? null,
+              missingLabel: "Sin plantilla de pronostico",
+            }
+      }
     />
   );
 }

--- a/app/(app)/eventos/[id]/page.tsx
+++ b/app/(app)/eventos/[id]/page.tsx
@@ -30,6 +30,7 @@ import EventoIncompletoBadge from "@/components/ui/evento-incompleto-badge";
 import UploadModal from "@/components/ui/upload-modal";
 import { getEvento, softDeleteEvento } from "@/lib/api/eventos";
 import { getAvalesByEvento, uploadConvocatoria } from "@/lib/api/avales";
+import { useDisciplinaPronosticoPlantilla } from "@/lib/hooks/use-catalog";
 import { downloadEventsTemplate } from "@/lib/api/template-download";
 import {
   canAccessReforms,
@@ -147,6 +148,8 @@ export default function EventoDetailPage() {
   const [pendingReformId, setPendingReformId] = useState<number | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const { sinPlantilla: disciplinaSinPlantilla } =
+    useDisciplinaPronosticoPlantilla(evento?.disciplinaId);
 
   useEffect(() => {
     if (!id || Number.isNaN(id)) {
@@ -330,8 +333,14 @@ export default function EventoDetailPage() {
   const formasDelTipoSeleccionado = formasConOcupacion.filter(
     (forma) => forma.tipoAval === tipoAval,
   );
-  const submitDisabled =
+  const faltaFormaParticipacion =
     formasDelTipoSeleccionado.length > 0 && formaParticipacionId == null;
+  // Sin plantilla de pronóstico el backend rechaza la creación del aval, así
+  // que se corta antes de que el entrenador suba los documentos.
+  const submitDisabled = faltaFormaParticipacion || disciplinaSinPlantilla;
+  const submitDisabledReason = disciplinaSinPlantilla
+    ? `La disciplina ${evento.disciplina?.nombre ?? "del evento"} no tiene una plantilla de pronóstico configurada. Pídele a un administrador que la configure antes de crear el aval.`
+    : "Selecciona una forma de participación para continuar.";
   // const canRequestReforma = canManageReforms && !hasPendingReform; // botón "Solicitar reforma" deshabilitado: reformas ya no se piden desde un evento puntual, ver /reformas
   const completionHref = `/eventos/${evento.id}/editar?mode=complete&next=${encodeURIComponent(
     `/eventos/${evento.id}`,
@@ -365,7 +374,7 @@ export default function EventoDetailPage() {
         description={`Sube la convocatoria y el certificado médico para crear el aval de "${evento.nombre}".`}
         requirePronosticoDeportistas={false}
         submitDisabled={submitDisabled}
-        submitDisabledReason="Selecciona una forma de participación para continuar."
+        submitDisabledReason={submitDisabledReason}
       >
         <AvalUploadOptions
           evento={evento}

--- a/lib/api/disciplinas.ts
+++ b/lib/api/disciplinas.ts
@@ -1,23 +1,33 @@
 import { apiFetch } from "@/lib/api/client";
-import type { CatalogItem } from "@/types/catalog";
+import type { CatalogItem, PronosticoPlantilla } from "@/types/catalog";
 
 export type CatalogPayload = {
   nombre: string;
   codigo?: string | null;
 };
 
+export type DisciplinaPayload = CatalogPayload & {
+  /** `null` desasigna la plantilla; omitirlo la deja como esta. */
+  pronosticoPlantillaId?: number | null;
+};
+
 export function getDisciplinas() {
   return apiFetch<CatalogItem[]>("/catalog/disciplinas");
 }
 
-export function createDisciplina(payload: CatalogPayload) {
+/** Plantillas disponibles para asignar a una disciplina (solo admin). */
+export function getPronosticoPlantillas() {
+  return apiFetch<PronosticoPlantilla[]>("/catalog/pronostico-plantillas");
+}
+
+export function createDisciplina(payload: DisciplinaPayload) {
   return apiFetch<CatalogItem>("/catalog/disciplinas", {
     method: "POST",
     body: JSON.stringify(payload),
   });
 }
 
-export function updateDisciplina(id: number, payload: CatalogPayload) {
+export function updateDisciplina(id: number, payload: DisciplinaPayload) {
   return apiFetch<CatalogItem>(`/catalog/disciplinas/${id}`, {
     method: "PATCH",
     body: JSON.stringify(payload),

--- a/lib/hooks/use-catalog.ts
+++ b/lib/hooks/use-catalog.ts
@@ -44,9 +44,11 @@ export function useDisciplinaPronosticoPlantilla(disciplinaId?: number | null) {
   return {
     isLoading,
     disciplina,
-    // Solo se afirma que falta cuando la disciplina vino en el catálogo: si
-    // aún está cargando o el catálogo falló, no se bloquea el flujo.
-    sinPlantilla: Boolean(disciplina && !disciplina.pronosticoPlantilla),
+    // Se compara contra `null` a propósito: el backend manda `null` cuando la
+    // disciplina no tiene plantilla, y omite el campo si aún no soporta la
+    // funcionalidad. Con `!plantilla` un backend viejo dejaría todas las
+    // disciplinas como "sin plantilla" y bloquearía la creación de avales.
+    sinPlantilla: disciplina?.pronosticoPlantilla === null,
   };
 }
 

--- a/lib/hooks/use-catalog.ts
+++ b/lib/hooks/use-catalog.ts
@@ -30,6 +30,27 @@ export function useCatalog() {
 }
 
 /**
+ * Estado de la plantilla de pronóstico de una disciplina. El backend rechaza
+ * la creación del aval cuando la disciplina no tiene plantilla configurada,
+ * así que conviene avisarlo antes de que el usuario cargue los documentos.
+ */
+export function useDisciplinaPronosticoPlantilla(disciplinaId?: number | null) {
+  const { disciplinas, isLoading } = useCatalog();
+
+  const disciplina = disciplinaId
+    ? disciplinas.find((item) => item.id === disciplinaId)
+    : undefined;
+
+  return {
+    isLoading,
+    disciplina,
+    // Solo se afirma que falta cuando la disciplina vino en el catálogo: si
+    // aún está cargando o el catálogo falló, no se bloquea el flujo.
+    sinPlantilla: Boolean(disciplina && !disciplina.pronosticoPlantilla),
+  };
+}
+
+/**
  * Catálogo de roles del sistema (`/roles`), con `id`, `codigo` y `nombre`.
  * Comparte queryKey `["roles"]` con la administración de roles, así que
  * renombrar un rol se refleja en todos los selects tras invalidar.

--- a/types/catalog.ts
+++ b/types/catalog.ts
@@ -1,8 +1,26 @@
+/** Motor que escribe el excel de pronostico: define que columnas se llenan. */
+export type MotorPronostico =
+  | "PRONOSTICO_1"
+  | "PRONOSTICO_2"
+  | "PRONOSTICO_3";
+
+export type PronosticoPlantilla = {
+  id: number;
+  codigo: string;
+  nombre: string;
+  motor: MotorPronostico;
+};
+
 export type CatalogItem = {
   id: number;
   nombre: string;
   codigo?: string | null;
   eventosCount?: number | null;
+  /**
+   * Solo disciplinas: plantilla usada para el excel de pronostico. Sin
+   * plantilla, el backend bloquea la creacion de avales de esa disciplina.
+   */
+  pronosticoPlantilla?: PronosticoPlantilla | null;
 };
 
 export type CatalogItemPresupuestario = {


### PR DESCRIPTION
## Que resuelve

El backend bloquea la creacion de avales cuando la disciplina no tiene plantilla de pronostico asignada, pero no habia forma de configurarla desde la app ni aviso previo al entrenador.

## Cambios

- **Catalogo de disciplinas**: select de plantilla en el formulario (consume `GET /catalog/pronostico-plantillas` y `PATCH /catalog/disciplinas/:id`) y badge de aviso en la tarjeta cuando la disciplina no tiene ninguna asignada. Se suma a `CatalogCrudView` como prop opcional `selectField`, asi que categorias queda igual.
- **Modal de convocatoria** (pagina de evento y aval nuevo): el submit queda deshabilitado con el motivo explicito si la disciplina no esta configurada, en vez de dejar que el usuario suba los documentos y reciba el 400 al final.
- La deteccion compara contra `null` (valor que manda el backend cuando no hay plantilla) y no contra un valor falsy, para que un backend sin soporte no marque todas las disciplinas como no configuradas.

## Notas

- No agrega peticiones nuevas al flujo del entrenador: reutiliza `useCatalog()`, ya cacheado con react-query, porque `/catalog` incluye ahora `pronosticoPlantilla` en cada disciplina.
- Requiere el backend con la migracion `20260726190000_add_pronostico_plantilla` aplicada (ya en produccion).
- Probado en qas.

## Verificacion

- `next build` OK (28/28 paginas)
- `eslint` sin errores nuevos