### PR TITLE
fix(avales): hacer obligatorio el detalle de los rubros en el paso 04

### DIFF
--- a/app/(app)/avales/_components/paso-04-presupuesto.tsx
+++ b/app/(app)/avales/_components/paso-04-presupuesto.tsx
@@ -373,6 +373,28 @@ export default function Paso04Presupuesto({
       }
 
       if (
+        usesManualRequirements &&
+        serializedManualRequirements.some((item) => !item.detalle?.trim())
+      ) {
+        setError("Cada requerimiento debe tener un detalle.");
+        return;
+      }
+
+      if (!usesManualRequirements && presupuestoItems.length > 0) {
+        const sinDetalle = presupuestoItems.filter(
+          (pi) => !(detallesByItemId[pi.item.id] ?? "").trim(),
+        );
+        if (sinDetalle.length > 0) {
+          setError(
+            `Completa el detalle de: ${sinDetalle
+              .map((pi) => pi.item.nombre)
+              .join(", ")}.`,
+          );
+          return;
+        }
+      }
+
+      if (
         isSoloResultado &&
         serializedManualRequirements.some((item) => {
           const monto = Number.parseFloat(item.montoSolicitado ?? "0");
@@ -475,7 +497,7 @@ export default function Paso04Presupuesto({
           : presupuestoItems.length > 0
             ? presupuestoItems.map((pi) => ({
                 formaParticipacionItemId: pi.id,
-                detalle: detallesByItemId[pi.item.id] || undefined,
+                detalle: detallesByItemId[pi.item.id]?.trim() || undefined,
               }))
             : undefined,
         observaciones: observaciones.trim() || undefined,
@@ -608,8 +630,7 @@ export default function Paso04Presupuesto({
                         </div>
                         <label className="block">
                           <span className="text-xs font-medium text-gray-600 dark:text-gray-300">
-                            Detalle{" "}
-                            <span className="font-normal text-gray-400">(opcional)</span>
+                            Detalle <span className="text-rose-500">*</span>
                           </span>
                           <input
                             type="text"
@@ -696,8 +717,7 @@ export default function Paso04Presupuesto({
                         </div>
                         <label className="block">
                           <span className="text-xs font-medium text-gray-600 dark:text-gray-300">
-                            Detalle{" "}
-                            <span className="font-normal text-gray-400">(opcional)</span>
+                            Detalle <span className="text-rose-500">*</span>
                           </span>
                           <input
                             type="text"
@@ -873,8 +893,7 @@ export default function Paso04Presupuesto({
 
                         <label className="block w-full">
                           <span className="text-xs font-medium text-gray-600 dark:text-gray-300">
-                            Detalle{" "}
-                            <span className="font-normal text-gray-400">(opcional)</span>
+                            Detalle <span className="text-rose-500">*</span>
                           </span>
                           <input
                             type="text"


### PR DESCRIPTION
Hotfix.

El detalle de cada rubro/requerimiento pasa de opcional a obligatorio en el paso 04 de la solicitud del aval:

- Labels `Detalle (opcional)` -> `Detalle *` en fondos publicos, autogestion y requerimientos manuales.
- Validacion en submit: bloquea el envio y lista los rubros sin detalle.
- `detalle` se envia trimeado en el payload.

Validacion solo en cliente; el backend sigue aceptando `detalle` opcional.