### PR TITLE
fix(pronosticos): arreglar la creación de pronosticos de deportes de conjunto

### DIFF
--- a/app/(app)/avales/_components/aval-document-preview.tsx
+++ b/app/(app)/avales/_components/aval-document-preview.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 import type { Aval, PropositoDto } from "@/types/aval";
 import {
@@ -17,10 +19,10 @@ import {
   getAvalPresupuestoItems,
 } from "@/lib/utils/aval-collections";
 import {
-  getPronosticoProfile,
   getPropositos,
   type PronosticoProfile,
 } from "@/lib/utils/aval-pronostico";
+import { usePronosticoProfile } from "@/lib/hooks/use-catalog";
 
 type FormData = {
   deportistas: Array<{
@@ -572,7 +574,7 @@ export default function AvalDocumentPreview({
   // genera para avales nuevos. Se reemplaza por el listado/pronóstico de
   // deportistas (más abajo) en las mismas vistas donde aparecía.
   const showNomina = false;
-  const pronosticoProfile = getPronosticoProfile(evento);
+  const pronosticoProfile = usePronosticoProfile(evento);
   const showListadoPronostico = mode !== "solicitud" && Boolean(pronosticoProfile);
   const showSolicitud = mode !== "nomina" && (showDetallePage || mode === "solicitud");
   const manualRequerimientos = (formData.requerimientos ?? []).filter(

--- a/app/(app)/avales/_components/paso-01-deportistas.tsx
+++ b/app/(app)/avales/_components/paso-01-deportistas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Search, X, Loader2 } from "lucide-react";
 import {
   listDeportistas,
@@ -23,7 +23,6 @@ import { useAuth } from "@/app/providers/auth-provider";
 import { getNormalizedRoles, isAdminUser } from "@/lib/auth/access";
 import { getAvalCupos } from "@/lib/utils/aval-collections";
 import {
-  getPronosticoProfile,
   ensureAtLeastOneProposito,
   createEmptyProposito,
   PROCEDENCIA_GROUP_FIELDS,
@@ -35,6 +34,7 @@ import {
   validatePronosticoDeportista,
   type PronosticoFieldErrors,
 } from "@/lib/validation/aval-pronostico";
+import { usePronosticoProfile } from "@/lib/hooks/use-catalog";
 
 const DEPORTISTA_SEARCH_MIN_LENGTH = 3;
 const DEPORTISTA_SEARCH_LIMIT = 10;
@@ -278,7 +278,7 @@ export default function Paso01Deportistas({
   onBack,
 }: Paso01DeportistasProps) {
   const { user } = useAuth();
-  const pronosticoProfile = getPronosticoProfile(aval.evento);
+  const pronosticoProfile = usePronosticoProfile(aval.evento);
   const categoriaEventoDefault =
     aval.evento?.categoria?.nombre?.trim() || undefined;
   const [fechaEmision, setFechaEmision] = useState(
@@ -339,22 +339,28 @@ export default function Paso01Deportistas({
     ),
   );
 
-  // Qué chips de cantón/club/entrenador están activos por deportista. No se
+  // Qué chips de cantón/club/entrenador tocó el usuario, por deportista. No se
   // deriva solo de los valores: un campo vacío puede ser "inactivo" (chip
-  // apagado) o "activo pero sin llenar" (error de validación).
+  // apagado) o "activo pero sin llenar" (error de validación). Los deportistas
+  // sin entrada usan el default de `procedenciaActivosResueltos`.
   const [procedenciaActivos, setProcedenciaActivos] = useState<
     Record<number, Set<DeportistaPronosticoFieldPath>>
-  >(() => {
+  >({});
+  // El perfil llega del catálogo (asíncrono), así que los defaults no pueden
+  // calcularse una sola vez al montar: se resuelven en cada render mientras el
+  // deportista no tenga elección propia guardada.
+  const procedenciaActivosResueltos = useMemo(() => {
     const map: Record<number, Set<DeportistaPronosticoFieldPath>> = {};
     for (const d of selectedDeportistas) {
-      map[d.id] = getDefaultProcedenciaActiva(d, pronosticoProfile);
+      map[d.id] =
+        procedenciaActivos[d.id] ?? getDefaultProcedenciaActiva(d, pronosticoProfile);
     }
     return map;
-  });
-  const procedenciaActivosRef = useRef(procedenciaActivos);
-  // getPronosticoProfile devuelve un objeto nuevo en cada render (no está
-  // memoizado): si entrara al arreglo de deps del effect de sincronización,
-  // lo dispararía en cada render y provocaría un loop de renders.
+  }, [selectedDeportistas, procedenciaActivos, pronosticoProfile]);
+  const procedenciaActivosRef = useRef(procedenciaActivosResueltos);
+  // El perfil se lee por ref en el effect de sincronización: solo interesa si
+  // existe o no, y no debe re-disparar el effect cuando el catálogo lo
+  // resuelve.
   const pronosticoProfileRef = useRef(pronosticoProfile);
   // Deportistas cuyo campo "Entrenador" fue escrito a mano: el effect de
   // sincronización con el entrenador principal ya no debe tocarlos.
@@ -579,7 +585,7 @@ export default function Paso01Deportistas({
   // activo en su lugar. procedenciaActivos se lee por ref (no como dep) para
   // no reprocesar todos los deportistas cada vez que se togglea un chip
   // ajeno, lo que pisaría ediciones manuales de otros deportistas.
-  procedenciaActivosRef.current = procedenciaActivos;
+  procedenciaActivosRef.current = procedenciaActivosResueltos;
   pronosticoProfileRef.current = pronosticoProfile;
   entrenadorManualOverridesRef.current = entrenadorManualOverrides;
 
@@ -706,15 +712,6 @@ export default function Paso01Deportistas({
       delete next[deportista.id];
       return next;
     });
-    if (pronosticoProfile) {
-      setProcedenciaActivos((prev) => ({
-        ...prev,
-        [deportista.id]: getDefaultProcedenciaActiva(
-          { canton: "", club: "", entrenadorNombre: entrenadorPrincipalNombre },
-          pronosticoProfile,
-        ),
-      }));
-    }
     setSearchDeportistas("");
   };
 
@@ -742,9 +739,10 @@ export default function Paso01Deportistas({
     deportistaId: number,
     path: DeportistaPronosticoFieldPath,
   ) => {
-    const wasActive = procedenciaActivos[deportistaId]?.has(path) ?? false;
+    const activos = procedenciaActivosResueltos[deportistaId];
+    const wasActive = activos?.has(path) ?? false;
     setProcedenciaActivos((prev) => {
-      const next = new Set(prev[deportistaId] ?? []);
+      const next = new Set(prev[deportistaId] ?? activos ?? []);
       if (wasActive) next.delete(path);
       else next.add(path);
       return { ...prev, [deportistaId]: next };
@@ -1012,7 +1010,7 @@ export default function Paso01Deportistas({
           const fieldErrors = validatePronosticoDeportista(
             deportista,
             pronosticoProfile,
-            procedenciaActivos[deportista.id],
+            procedenciaActivosResueltos[deportista.id],
           );
           if (Object.keys(fieldErrors).length > 0) {
             acc[deportista.id] = fieldErrors;
@@ -1194,7 +1192,7 @@ export default function Paso01Deportistas({
                       defaultCategoriaNombre={categoriaEventoDefault}
                       errors={pronosticoErrors[deportista.id]}
                       activePaths={
-                        procedenciaActivos[deportista.id] ??
+                        procedenciaActivosResueltos[deportista.id] ??
                         new Set<DeportistaPronosticoFieldPath>()
                       }
                       onToggleActive={(path) =>

--- a/lib/hooks/use-catalog.ts
+++ b/lib/hooks/use-catalog.ts
@@ -1,10 +1,16 @@
 "use client";
 
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { getCatalog } from "@/lib/api/catalog";
 import { listRoles } from "@/lib/api/roles";
+import {
+  getPronosticoProfile,
+  type PronosticoProfile,
+} from "@/lib/utils/aval-pronostico";
 import type { CatalogItem } from "@/types/catalog";
+import type { Evento } from "@/types/evento";
 import type { Role } from "@/types/role";
 
 /** Los catálogos cambian con muy poca frecuencia: cache más largo que el default. */
@@ -50,6 +56,47 @@ export function useDisciplinaPronosticoPlantilla(disciplinaId?: number | null) {
     // disciplinas como "sin plantilla" y bloquearía la creación de avales.
     sinPlantilla: disciplina?.pronosticoPlantilla === null,
   };
+}
+
+type EventoPronostico = Pick<Evento, "disciplina" | "disciplinaCodigo">;
+
+/**
+ * Perfil de pronóstico del evento (qué campos se piden por deportista),
+ * resuelto con la plantilla que el catálogo trae para la disciplina. El nombre
+ * de la disciplina no alcanza: la plantilla se configura desde catálogos, así
+ * que una disciplina nueva (ej. "Voleibol Playa") solo muestra sus campos si
+ * se lee del catálogo.
+ */
+export function usePronosticoProfile(
+  evento?: EventoPronostico | null,
+): PronosticoProfile | null {
+  const { disciplinas } = useCatalog();
+  const disciplinaId = evento?.disciplina?.id;
+  const disciplinaNombre = evento?.disciplina?.nombre;
+  const disciplinaCodigo = evento?.disciplinaCodigo ?? evento?.disciplina?.codigo;
+
+  const plantilla = disciplinaId
+    ? disciplinas.find((item) => item.id === disciplinaId)?.pronosticoPlantilla
+    : undefined;
+  // `undefined` (disciplina no encontrada o backend sin el campo) deja que el
+  // perfil caiga al mapa por código; `null` es "sin plantilla configurada".
+  const motor = plantilla ? plantilla.motor : plantilla;
+
+  // El objeto `evento` cambia de identidad en cada render de los pasos del
+  // aval, así que el memo se apoya en los datos de la disciplina.
+  return useMemo(
+    () =>
+      getPronosticoProfile(
+        {
+          disciplina: disciplinaId
+            ? { id: disciplinaId, nombre: disciplinaNombre ?? "" }
+            : null,
+          disciplinaCodigo,
+        },
+        motor,
+      ),
+    [disciplinaId, disciplinaNombre, disciplinaCodigo, motor],
+  );
 }
 
 /**

--- a/lib/utils/aval-pronostico.ts
+++ b/lib/utils/aval-pronostico.ts
@@ -1,10 +1,8 @@
 import type { Evento } from "@/types/evento";
 import type { PropositoDto } from "@/types/aval";
+import type { MotorPronostico } from "@/types/catalog";
 
-export type PronosticoTemplate =
-  | "PRONOSTICO_1"
-  | "PRONOSTICO_2"
-  | "PRONOSTICO_3";
+export type PronosticoTemplate = MotorPronostico;
 
 // "proposito.*" son los campos que viven dentro de cada ítem de
 // deportistasAval[].propositos (ver types/aval.ts#PropositoDto). No es un
@@ -55,10 +53,15 @@ export const PROCEDENCIA_GROUP_FIELDS: DeportistaPronosticoFieldPath[] = [
 export const PROCEDENCIA_DEFAULT_FIELD: DeportistaPronosticoFieldPath =
   "entrenadorNombre";
 
+// Fallback para backends que todavía no exponen `pronosticoPlantilla` en el
+// catálogo de disciplinas: replica el mapa que el backend migró a la tabla
+// `PronosticoPlantilla`. La fuente de verdad es el catálogo, no estas listas:
+// una disciplina nueva (o renombrada) se configura desde catálogos.
 const DISCIPLINAS_PRONOSTICO_1 = new Set([
   "BALONCESTO",
   "FUTBOL",
   "VOLEIBOL",
+  "VOLEIBOL_PLAYA",
 ]);
 
 const DISCIPLINAS_PRONOSTICO_2 = new Set([
@@ -222,13 +225,22 @@ function resolvePronosticoTemplate(
   return null;
 }
 
+/**
+ * `motor` viene de la plantilla configurada en el catálogo de disciplinas
+ * (ver `usePronosticoProfile`): es la fuente de verdad. `undefined` significa
+ * "el catálogo no lo dice" (backend viejo o disciplina no encontrada) y cae al
+ * mapa hardcodeado; `null` significa "disciplina sin plantilla configurada",
+ * el mismo caso en que el backend bloquea la creación del aval.
+ */
 export function getPronosticoProfile(
   evento?: Pick<Evento, "disciplina" | "disciplinaCodigo"> | null,
+  motor?: MotorPronostico | null,
 ): PronosticoProfile | null {
   const disciplinaCodigo = normalizeDisciplinaKey(
     evento?.disciplinaCodigo ?? evento?.disciplina?.codigo ?? evento?.disciplina?.nombre,
   );
-  const template = resolvePronosticoTemplate(disciplinaCodigo);
+  const template =
+    motor === undefined ? resolvePronosticoTemplate(disciplinaCodigo) : motor;
 
   if (!template) return null;
 


### PR DESCRIPTION
## Problema

El perfil de pronóstico se resolvía con listas de disciplinas hardcodeadas en el frontend (`DISCIPLINAS_PRONOSTICO_1/2/3`). Una disciplina fuera de esas listas —ej. **Voleibol Playa**— daba `getPronosticoProfile() === null`, así que en el paso 01 no aparecían los campos por deportista (procedencia, ubicación actual/propósito) ni el bloque "Lista deportistas" del preview, aunque el catálogo ya tuviera su plantilla configurada.

## Cambios

- `lib/utils/aval-pronostico.ts`: `getPronosticoProfile(evento, motor?)` acepta el motor de la plantilla del catálogo. `undefined` cae al mapa por código (backend que aún no expone el campo), `null` es "disciplina sin plantilla" —el mismo caso que el backend bloquea al crear el aval. `PronosticoTemplate` reusa `MotorPronostico`.
- `lib/hooks/use-catalog.ts`: nuevo `usePronosticoProfile(evento)`, que busca la disciplina en `/catalog` por id y memoiza el perfil por los datos de la disciplina (el objeto `evento` cambia de identidad en cada render).
- `paso-01-deportistas.tsx`: usa el hook. Como el perfil llega asíncrono, los chips de procedencia se resuelven por render mientras el deportista no tenga elección propia guardada, en vez de sembrarse al montar (antes quedaban vacíos si el perfil llegaba después).
- `aval-document-preview.tsx`: `"use client"` + hook; sus consumidores ya eran client components.

## Verificación

- `pnpm exec tsc --noEmit` limpio.
- `pnpm build` OK.
- `pnpm lint` sin errores nuevos.

## Nota de datos

La migración `20260726190000_add_pronostico_plantilla` asigna PRONOSTICO_1 con `d.codigo IN (... 'VOLEIBOL PLAYA')` (con espacio), pero el seed crea esa disciplina con codigo `VOLEIBOL_PLAYA`. Si no coincidió, la disciplina quedó sin plantilla en BD y hay que asignarla desde Catálogos → Disciplinas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)